### PR TITLE
Demo Space installs SDK from PyPI

### DIFF
--- a/sdk/demo/requirements.txt
+++ b/sdk/demo/requirements.txt
@@ -5,4 +5,4 @@ transformers>=4.44,<4.45
 huggingface_hub>=0.23
 sentencepiece>=0.2
 numpy>=1.26
-unplug-ai @ git+https://github.com/UnplugAI/Unplug.git@d925c550261b8f98e76b42561db08ac8034d6644#subdirectory=sdk
+unplug-ai==0.2.0


### PR DESCRIPTION
## Summary
- Swap the git commit pin for `unplug-ai==0.2.0` now that the release is live on PyPI

## Test plan
- [x] Same file uploaded to the Space; rebuild verified RUNNING