### PR TITLE
Sync uv.lock to 0.2.0

### DIFF
--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -2514,7 +2514,7 @@ wheels = [
 
 [[package]]
 name = "unplug-ai"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Lockfile self-reference still said 0.1.0 after the version bump; sync so `uv sync --locked` passes

## Test plan
- [x] `uv sync --all-extras --dev` resolves cleanly