### PR TITLE
Fix open Greptile P1 review items

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Publish unplug-ai
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: uv publish
+        run: uv publish --check-url https://pypi.org/pypi/unplug-ai/json

--- a/sdk/src/unplug/core/encodings.py
+++ b/sdk/src/unplug/core/encodings.py
@@ -7,7 +7,7 @@ import re
 from typing import TYPE_CHECKING, Protocol
 
 from unplug.api.types import Finding
-from unplug.core.normalize import Normalizer
+from unplug.core.normalize import _MAX_BASE64_DECODED_SIZE, Normalizer
 from unplug.safeguards.injection.patterns import INJECTION_PATTERNS
 
 if TYPE_CHECKING:
@@ -141,7 +141,10 @@ def iter_base64_blobs(text: str) -> list[EncodingBlob]:
             continue
         decoded: str | None = None
         try:
-            decoded = base64.b64decode(raw, validate=True).decode("utf-8")
+            decoded_bytes = base64.b64decode(raw, validate=True)
+            if len(decoded_bytes) > _MAX_BASE64_DECODED_SIZE:
+                continue
+            decoded = decoded_bytes.decode("utf-8")
         except Exception:
             continue
         if not _is_plausible_decoded_payload(decoded):

--- a/sdk/src/unplug/core/normalize.py
+++ b/sdk/src/unplug/core/normalize.py
@@ -450,24 +450,18 @@ def _strip_delimiters(text: str, offset_table: list[int]) -> tuple[str, list[int
             break
         current_text, current_offsets = new_text, result_offsets
 
-    pipe_between = re.compile(r"(?<=[a-zA-Z])\|(?=[a-zA-Z])")
-    if pipe_between.search(current_text):
+    pipe_evasion = (
+        re.compile(r"(?<=[a-zA-Z])\|(?=[a-zA-Z])"),
+        re.compile(r"(?<=[a-zA-Z])\|(?=\s)"),
+        re.compile(r"(?<=\s)\|(?=[a-zA-Z])"),
+    )
+    for pattern in pipe_evasion:
+        if not pattern.search(current_text):
+            continue
         result_chars = []
         result_offsets = []
         for i, ch in enumerate(current_text):
-            if ch == "|" and i > 0 and i + 1 < len(current_text):
-                if current_text[i - 1].isalpha() and current_text[i + 1].isalpha():
-                    continue
-            result_chars.append(ch)
-            result_offsets.append(current_offsets[i])
-        current_text = "".join(result_chars)
-        current_offsets = result_offsets
-
-    if "|" in current_text:
-        result_chars = []
-        result_offsets = []
-        for i, ch in enumerate(current_text):
-            if ch == "|":
+            if ch == "|" and pattern.match(current_text, i):
                 continue
             result_chars.append(ch)
             result_offsets.append(current_offsets[i])

--- a/sdk/src/unplug/core/secrets.py
+++ b/sdk/src/unplug/core/secrets.py
@@ -169,6 +169,18 @@ class SecretsRegistry:
         return result
 
 
+def _merge_spans(spans: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    if not spans:
+        return []
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
 class SecretsSanitizer:
     """Sanitizes text by replacing all detected secrets."""
 
@@ -184,7 +196,7 @@ class SecretsSanitizer:
             for m in pat.finditer(clean):
                 generic_spans.append((m.start(), m.end()))
 
-        for start, end in sorted(generic_spans, reverse=True):
+        for start, end in sorted(_merge_spans(generic_spans), reverse=True):
             clean = clean[:start] + "[REDACTED]" + clean[end:]
 
         return SanitizeResult(clean_text=clean, secrets_found=matches)

--- a/sdk/src/unplug/pipelines/input.py
+++ b/sdk/src/unplug/pipelines/input.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 from unplug.config.agent_policy import BoundaryConfig, DegradationConfig, TrajectoryConfig
+from unplug.core.asyncio_compat import run_coroutine_sync
 from unplug.core.boundaries import maybe_wrap_untrusted
 from unplug.core.config import PipelineConfig
 from unplug.core.context import ExecutionContext
@@ -122,17 +122,7 @@ class InputPipeline(BasePipeline):
             return []
         judge_ctx = JudgeContext(scanner_findings=findings)
         try:
-            try:
-                loop = asyncio.get_running_loop()
-            except RuntimeError:
-                result = asyncio.run(self._judge.judge(input_data.text, judge_ctx))
-            else:
-                future = asyncio.run_coroutine_threadsafe(
-                    self._judge.judge(input_data.text, judge_ctx),
-                    loop,
-                )
-                timeout = self._config.judge_timeout
-                result = future.result(timeout=timeout)
+            result = run_coroutine_sync(self._judge.judge(input_data.text, judge_ctx))
         except Exception as exc:
             _log.error("input pipeline judge failed: %s", exc)
             return [

--- a/sdk/src/unplug/safeguards/leakage.py
+++ b/sdk/src/unplug/safeguards/leakage.py
@@ -29,8 +29,10 @@ LEAKAGE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("jwt_token", re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+")),
     ("email_address", re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")),
     ("phone_number", re.compile(r"\b(\+?1?\s?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4})\b")),
-    ("ssn", re.compile(r"\b\d{3}[\s.-]?\d{2}[\s.-]?\d{4}\b")),
-    ("ssn_compact", re.compile(r"\b\d{3}\d{2}\d{4}\b")),
+    (
+        "ssn",
+        re.compile(r"\b(?!000|666|9\d{2})\d{3}[\s.-]?\d{2}[\s.-]?\d{4}\b"),
+    ),
     (
         "system_prompt_leak",
         re.compile(

--- a/sdk/tests/test_asyncio_compat.py
+++ b/sdk/tests/test_asyncio_compat.py
@@ -1,0 +1,22 @@
+"""Tests for sync/async bridge helpers."""
+
+from __future__ import annotations
+
+import asyncio
+
+from unplug.core.asyncio_compat import run_coroutine_sync
+
+
+async def _return_value(value: str) -> str:
+    return value
+
+
+class TestRunCoroutineSync:
+    def test_runs_without_active_loop(self) -> None:
+        assert run_coroutine_sync(_return_value("ok")) == "ok"
+
+    def test_runs_from_active_loop_thread(self) -> None:
+        async def _runner() -> str:
+            return run_coroutine_sync(_return_value("nested"))
+
+        assert asyncio.run(_runner()) == "nested"

--- a/sdk/tests/test_encodings.py
+++ b/sdk/tests/test_encodings.py
@@ -76,6 +76,12 @@ class TestEncodingBlobs:
         text = f"token={short}"
         assert iter_base64_blobs(text) == []
 
+    def test_oversized_decode_skipped(self) -> None:
+        payload = "x" * 10_001
+        blob = base64.b64encode(payload.encode()).decode()
+        text = f"payload={blob}"
+        assert iter_base64_blobs(text) == []
+
 
 class TestEncodingClassifiers:
     def test_heuristic_classifier(self) -> None:

--- a/sdk/tests/test_normalize.py
+++ b/sdk/tests/test_normalize.py
@@ -244,6 +244,21 @@ class TestStripDelimiters:
         assert offsets[0] == 0  # 'i' at pos 0
         assert offsets[1] == 2  # 'g' at pos 2
 
+    def test_pipe_separated_evasion(self):
+        text = "i|g|n|o|r|e"
+        result, _ = _strip_delimiters(text, _make_table(text))
+        assert result == "ignore"
+
+    def test_shell_pipe_preserved(self):
+        text = "ls | grep secret"
+        result, _ = _strip_delimiters(text, _make_table(text))
+        assert result == text
+
+    def test_cross_word_pipe_evasion(self):
+        text = "i|g|n|o|r|e| |p|r|e|v|i|o|u|s"
+        result, _ = _strip_delimiters(text, _make_table(text))
+        assert result == "ignore previous"
+
 
 class TestMatchCrossLanguage:
     def test_spanish_ignore(self):

--- a/sdk/tests/test_scanners.py
+++ b/sdk/tests/test_scanners.py
@@ -252,7 +252,17 @@ class TestLeakageScanner:
     def test_detects_spaced_ssn(self):
         text = _make_text("SSN 123 45 6789", trust=TrustLevel.RETRIEVED)
         findings = self.scanner.scan(text, self.ctx)
-        assert any(f.subcategory in ("ssn", "ssn_compact") for f in findings)
+        assert any(f.subcategory == "ssn" for f in findings)
+
+    def test_compact_ssn_without_redundant_pattern(self):
+        text = _make_text("SSN 123456789", trust=TrustLevel.RETRIEVED)
+        findings = self.scanner.scan(text, self.ctx)
+        assert any(f.subcategory == "ssn" for f in findings)
+
+    def test_nine_digit_order_id_not_ssn(self):
+        text = _make_text("order id 987654321", trust=TrustLevel.TOOL_OUTPUT)
+        findings = self.scanner.scan(text, self.ctx)
+        assert not any(f.subcategory in ("ssn", "ssn_compact") for f in findings)
 
     def test_detects_zero_width_email(self):
         text = _make_text("contact test\u200b@example.com today", trust=TrustLevel.RETRIEVED)

--- a/sdk/tests/test_secrets.py
+++ b/sdk/tests/test_secrets.py
@@ -149,6 +149,15 @@ class TestSecretsSanitizer:
         assert "sk-" not in result.clean_text
         assert result.clean_text.count("[REDACTED]") >= 2
 
+    def test_sanitize_overlapping_generic_spans(self):
+        reg = SecretsRegistry()
+        sanitizer = SecretsSanitizer(reg)
+        text = "export api_key=sk-abcdefghijklmnopqrstuvwxyz1234567890abcdef"
+        result = sanitizer.sanitize(text)
+        assert "sk-" not in result.clean_text
+        assert "api_key=" not in result.clean_text
+        assert "[REDACTED]" in result.clean_text
+
     def test_register_redos_pattern_rejected(self):
         reg = SecretsRegistry()
         with pytest.raises(ValueError, match="backtracking"):


### PR DESCRIPTION
## Summary
Addresses the six Greptile P1 items still open on `main` after PRs #2-#4 (PR #7 had no Greptile review):

- **Judge deadlock:** `InputPipeline._maybe_judge` now uses `run_coroutine_sync` instead of `run_coroutine_threadsafe` on the caller loop thread
- **Pipe evasion vs shell pipes:** removed unconditional `|` strip; keep alpha|alpha plus letter|space and space|letter evasion passes while preserving `ls | grep`
- **SSN false positives:** dropped redundant `ssn_compact` and reject invalid SSN area codes (000/666/9xx) in the main `ssn` pattern
- **Secrets sanitize:** merge overlapping generic spans before redaction
- **Base64 decode cap:** `iter_base64_blobs` skips decoded payloads over 10KB (matches `normalize`)
- **PyPI publish:** `uv publish --check-url` so release re-runs skip already-uploaded versions

## Test plan
- [x] `make check-ci` green locally (635 tests)
- [x] New coverage: asyncio bridge, pipe evasion/shell pipe, overlapping secrets, oversized base64, SSN area validation
- [ ] CI green on PR