### PR TITLE
Release 0.2.1

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unplug-ai"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pull the plug on bad AI. Fast prompt injection detection and redaction for LLM apps, agents, and RAG pipelines."
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/unplug/__init__.py
+++ b/sdk/src/unplug/__init__.py
@@ -68,4 +68,4 @@ try:
     # Single source of truth is pyproject.toml; avoids version drift.
     __version__ = _pkg_version("unplug-ai")
 except PackageNotFoundError:  # not installed (e.g. running from a source checkout)
-    __version__ = "0.2.0"
+    __version__ = "0.2.1"

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -2514,7 +2514,7 @@ wheels = [
 
 [[package]]
 name = "unplug-ai"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Patch release for Greptile P1 fixes merged in #10 (judge deadlock, pipe evasion, SSN FP, secrets overlap, base64 cap, idempotent PyPI publish)

## Test plan
- [x] `pytest tests/test_infrastructure.py` green
- [ ] CI green
- [ ] Post-merge: tag `v0.2.1`, dispatch Publish to PyPI, verify `pip install unplug-ai==0.2.1`