### PR TITLE
Demo Space pins SDK 0.2.1

### DIFF
--- a/sdk/demo/requirements.txt
+++ b/sdk/demo/requirements.txt
@@ -5,4 +5,4 @@ transformers>=4.44,<4.45
 huggingface_hub>=0.23
 sentencepiece>=0.2
 numpy>=1.26
-unplug-ai==0.2.0
+unplug-ai==0.2.1


### PR DESCRIPTION
Bump demo requirements after 0.2.1 PyPI release.