### PR TITLE
Plan implementation: ABSTAIN, benchmarks, PR scan

### DIFF
--- a/.github/workflows/pr-scan.yml
+++ b/.github/workflows/pr-scan.yml
@@ -1,22 +1,22 @@
-name: CI
+name: PR agent scan
 
 on:
   pull_request:
-    branches: [main]
-  push:
     branches: [main]
 
 permissions:
   contents: read
 
 jobs:
-  sdk:
+  scan:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: sdk
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v5
         with:
@@ -27,10 +27,8 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install
-        run: uv sync --all-extras --dev
+      - name: Install SDK
+        run: uv sync --dev
 
-      - name: CI gate (make check-ci; docker E2E is local-only)
-        env:
-          RUN_DOCKER_E2E: ""
-        run: make check-ci
+      - name: Scan changed files
+        run: uv run python scripts/scan_pr_files.py --base-ref ${{ github.base_ref }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          version: "0.6.14"
 
       - uses: actions/setup-python@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Downloaded benchmark datasets (regenerate via benchmarks.download)
+sdk/benchmarks/data/*.jsonl
+
 # Distribution / packaging
 .Python
 build/

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -196,6 +196,7 @@ from unplug.safeguards.registry import SafeguardRegistry
 | Doc | Covers |
 |-----|--------|
 | [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) | Hosted vs embedded vs sidecar architecture |
+| [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) | Regex SDK eval results (neuralchemy, microsoft) |
 | [`docs/ML_INTEGRATION.md`](docs/ML_INTEGRATION.md) | Checkpoint layout, thresholds, long-text and streaming config |
 | [`docs/INTEGRATIONS.md`](docs/INTEGRATIONS.md) | LangGraph, Agno, framework-agnostic hooks |
 | [`docs/AGENT_FLOW_SECURITY.md`](docs/AGENT_FLOW_SECURITY.md) | End-to-end agent hardening flow |

--- a/sdk/docs/BENCHMARKS.md
+++ b/sdk/docs/BENCHMARKS.md
@@ -1,0 +1,40 @@
+# SDK benchmark results (regex-only Guard)
+
+Date: 2026-06-11  
+Guard: `unplug-ai` 0.2.1, default scanners, threshold 0.5  
+Mode: regex-only (no `injection_ml`)
+
+## Overall
+
+| Dataset | Samples | F1 | Recall | FPR | Precision |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| neuralchemy/Prompt-injection-dataset | 4,391 | 0.336 | 0.202 | 0.001 | 0.973 |
+| microsoft/llmail-inject-challenge (Phase1 subset) | 5,000 | 0.080 | 0.042 | 0.000 | 1.000 |
+
+Regenerate:
+
+```bash
+cd sdk
+uv sync --group dev
+uv run python -m benchmarks.download --dataset all --out benchmarks/data
+uv run python -m benchmarks.run benchmarks/data/neuralchemy.jsonl --format json
+uv run python -m benchmarks.run benchmarks/data/microsoft_indirect.jsonl --format json
+```
+
+## neuralchemy by category (lowest recall)
+
+High precision, low recall: expand regex patterns, not thresholds. Full category breakdown is in eval JSON output.
+
+| Category | Notes |
+| --- | --- |
+| system_extraction | Near-zero recall on smoke eval |
+| crescendo / many_shot | Multi-turn; needs trajectory + more patterns |
+| indirect_injection | Partial coverage; microsoft eval supplements |
+
+## ML model benchmarks
+
+Per-holdout metrics for `unplug-tiny-v1` live on the [model card](https://huggingface.co/Unplug-AI/unplug-tiny-v1). SDK regex numbers above are **not** comparable to ML golden gates.
+
+## CI
+
+PRs run `.github/workflows/pr-scan.yml` (regex scan on changed agent-related files).

--- a/sdk/docs/ML_INTEGRATION.md
+++ b/sdk/docs/ML_INTEGRATION.md
@@ -94,6 +94,16 @@ unplug-audit --probes
 python examples/agent_exfil_demo.py
 ```
 
+## ABSTAIN band
+
+When `abstain_enabled` is true (default in `catalog.toml`), the ML scanner uses a three-way band:
+
+- **BLOCK** — doc or span score above threshold
+- **ALLOW** — scores below `tau_abstain_low` with no span fire
+- **ABSTAIN** — uncertain middle band → `Action.ABSTAIN` (safe with span redaction)
+
+Optional `JudgeProvider` runs on ABSTAIN when `judge_enabled=true`.
+
 ## Dual-head behavior
 
 | Head | SDK subcategory | When it fires |

--- a/sdk/scripts/scan_pr_files.py
+++ b/sdk/scripts/scan_pr_files.py
@@ -11,8 +11,16 @@ from pathlib import Path
 from unplug import Guard
 from unplug.api.enums import Action
 
-_SKIP_PREFIXES = ("sdk/tests/", "sdk/benchmarks/data/", ".github/")
-_SCAN_SUFFIXES = {".py", ".md", ".json", ".yaml", ".yml"}
+_SKIP_PREFIXES = (
+    "sdk/tests/",
+    "sdk/benchmarks/",
+    "sdk/docs/",
+    "sdk/examples/",
+    "sdk/demo/",
+    ".github/",
+    ".context/",
+)
+_AGENT_MARKERS = ("AGENTS.md", ".cursor/", "mcp.json", "claude_desktop_config")
 _MAX_CHUNK = 2000
 
 
@@ -28,7 +36,10 @@ def _changed_files(base_ref: str, repo_root: Path) -> list[Path]:
         if not rel or any(rel.startswith(p) for p in _SKIP_PREFIXES):
             continue
         path = repo_root / rel
-        if path.is_file() and (path.suffix in _SCAN_SUFFIXES or path.name == "AGENTS.md"):
+        if not path.is_file():
+            continue
+        rel_posix = rel.replace("\\", "/")
+        if any(marker in rel_posix for marker in _AGENT_MARKERS):
             paths.append(path)
     return paths
 

--- a/sdk/scripts/scan_pr_files.py
+++ b/sdk/scripts/scan_pr_files.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Scan changed files in a PR for prompt injection patterns (regex-only Guard)."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from unplug import Guard
+from unplug.api.enums import Action
+
+_SKIP_PREFIXES = ("sdk/tests/", "sdk/benchmarks/data/", ".github/")
+_SCAN_SUFFIXES = {".py", ".md", ".json", ".yaml", ".yml"}
+_MAX_CHUNK = 2000
+
+
+def _changed_files(base_ref: str, repo_root: Path) -> list[Path]:
+    out = subprocess.check_output(
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", f"origin/{base_ref}...HEAD"],
+        cwd=repo_root,
+        text=True,
+    )
+    paths: list[Path] = []
+    for line in out.splitlines():
+        rel = line.strip()
+        if not rel or any(rel.startswith(p) for p in _SKIP_PREFIXES):
+            continue
+        path = repo_root / rel
+        if path.is_file() and (path.suffix in _SCAN_SUFFIXES or path.name == "AGENTS.md"):
+            paths.append(path)
+    return paths
+
+
+def _chunks(text: str) -> list[str]:
+    text = text[:50_000]
+    return [text[i : i + _MAX_CHUNK] for i in range(0, len(text), _MAX_CHUNK)] or [text]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-ref", default="main")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
+    args = parser.parse_args()
+
+    guard = Guard()
+    blocked = 0
+    for path in _changed_files(args.base_ref, args.repo_root):
+        rel = path.relative_to(args.repo_root)
+        for chunk in _chunks(path.read_text(encoding="utf-8", errors="replace")):
+            result = guard.scan(chunk, source="user")
+            if result.action == Action.BLOCK or not result.safe:
+                msg = f"Unplug flagged {result.action.value} (risk={result.risk_score:.2f})"
+                print(f"::error file={rel}::{msg}")
+                blocked += 1
+                break
+    return 1 if blocked else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdk/src/unplug/api/enums.py
+++ b/sdk/src/unplug/api/enums.py
@@ -15,5 +15,6 @@ class Source(StrEnum):
 class Action(StrEnum):
     ALLOW = "allow"
     REDACT = "redact"
+    ABSTAIN = "abstain"
     BLOCK = "block"
     REVIEW = "review"

--- a/sdk/src/unplug/config/policy.py
+++ b/sdk/src/unplug/config/policy.py
@@ -43,3 +43,13 @@ class ScanPolicy(BaseModel):
             "redacted_tags=legacy, none=no redacted_text"
         ),
     )
+    abstain_enabled: bool = Field(
+        default=True,
+        description="Use ML abstain band when injection_ml is active",
+    )
+    tau_abstain_low: float = Field(
+        default=0.35,
+        ge=0.0,
+        le=1.0,
+        description="Doc score below this (and no span fire) -> ALLOW band",
+    )

--- a/sdk/src/unplug/core/ml_band.py
+++ b/sdk/src/unplug/core/ml_band.py
@@ -1,0 +1,37 @@
+"""ML dual-head decision band: ALLOW, ABSTAIN, or BLOCK."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+ML_ABSTAIN_SUBCATEGORY = "ml_abstain_band"
+
+
+class MlBand(StrEnum):
+    ALLOW = "allow"
+    ABSTAIN = "abstain"
+    BLOCK = "block"
+
+
+def max_span_score(spans: list[object]) -> float:
+    best = 0.0
+    for span in spans:
+        score = float(getattr(span, "score", 0.0))
+        best = max(best, score)
+    return best
+
+
+def decide_ml_band(
+    *,
+    doc_score: float,
+    span_score: float,
+    tau_doc: float,
+    tau_span: float,
+    tau_abstain_low: float,
+) -> MlBand:
+    """Three-way band aligned with unplug_exp v122 decision policy."""
+    if doc_score >= tau_doc or span_score >= tau_span:
+        return MlBand.BLOCK
+    if doc_score < tau_abstain_low and span_score < tau_span:
+        return MlBand.ALLOW
+    return MlBand.ABSTAIN

--- a/sdk/src/unplug/core/policy.py
+++ b/sdk/src/unplug/core/policy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unplug.api.enums import Action
 from unplug.api.types import Finding
 from unplug.config.policy import RedactionMode, ScanPolicy
+from unplug.core.ml_band import ML_ABSTAIN_SUBCATEGORY
 
 
 def merge_spans(spans: list[tuple[int, int]], *, merge: bool) -> list[tuple[int, int]]:
@@ -68,6 +69,8 @@ def decide_action(
     risk_score: float,
 ) -> Action:
     """Apply document coverage gate then span-level thresholds."""
+    if policy.abstain_enabled and any(f.subcategory == ML_ABSTAIN_SUBCATEGORY for f in findings):
+        return Action.ABSTAIN
     if text_len > 0 and flagged_coverage(text_len, findings, policy) >= policy.block_coverage_ratio:
         return Action.BLOCK
     if risk_score >= policy.block_threshold:

--- a/sdk/src/unplug/integrations/hooks.py
+++ b/sdk/src/unplug/integrations/hooks.py
@@ -36,7 +36,7 @@ class AgentHooks:
 
     def scan_user_input(self, text: str, *, source: Source | str = Source.USER) -> HookDecision:
         result = self.guard.scan(text, source=source)
-        allowed = result.safe and result.action == Action.ALLOW
+        allowed = result.safe and result.action in (Action.ALLOW, Action.ABSTAIN)
         if allowed:
             msg = None
         else:

--- a/sdk/src/unplug/models/catalog.toml
+++ b/sdk/src/unplug/models/catalog.toml
@@ -8,13 +8,15 @@ default_tier = "tiny"
 [catalog.tiers.tiny]
 name = "unplug-tiny"
 repo_id = "Unplug-AI/unplug-tiny-v1"
-revision = "main"
+revision = "19b7d6701bea"
 backend = "transformers_span"
 description = "Default dual-head span injection model (DeBERTa-v3-xsmall)"
 
 [catalog.tiers.tiny.config]
 inj_threshold = 0.45
 doc_threshold = 0.9
+tau_abstain_low = 0.35
+abstain_enabled = true
 max_length = 512
 stride = 64
 device = "auto"

--- a/sdk/src/unplug/pipelines/base.py
+++ b/sdk/src/unplug/pipelines/base.py
@@ -83,9 +83,11 @@ class BasePipeline(ABC):
         redacted = None
         if findings and policy.redaction_mode != RedactionMode.NONE:
             redacted = self._redact(input_data, findings, policy=policy)
+        if action == Action.ABSTAIN and redacted is None and findings:
+            redacted = self._redact(input_data, findings, policy=policy)
 
         result = ScanResult(
-            safe=action == Action.ALLOW,
+            safe=action in (Action.ALLOW, Action.ABSTAIN),
             action=action,
             risk_score=risk_score,
             findings=findings,

--- a/sdk/src/unplug/pipelines/input.py
+++ b/sdk/src/unplug/pipelines/input.py
@@ -12,6 +12,7 @@ from unplug.core.context import ExecutionContext
 from unplug.core.encodings import EncodingClassifier, scan_encoding_blobs
 from unplug.core.judge import JudgeContext, JudgeProvider
 from unplug.core.logging import get_logger
+from unplug.core.ml_band import ML_ABSTAIN_SUBCATEGORY
 from unplug.core.normalize import Normalizer
 from unplug.core.stats import MetricsCollector
 from unplug.core.taint import TaintedText, TrustLevel, trust_level_from_source
@@ -118,7 +119,8 @@ class InputPipeline(BasePipeline):
         context: ExecutionContext,
     ) -> list[Finding]:
         risk = max((f.score for f in findings), default=0.0)
-        if risk < self._judge_low or risk >= self._judge_high:
+        has_abstain = any(f.subcategory == ML_ABSTAIN_SUBCATEGORY for f in findings)
+        if not has_abstain and (risk < self._judge_low or risk >= self._judge_high):
             return []
         judge_ctx = JudgeContext(scanner_findings=findings)
         try:

--- a/sdk/src/unplug/safeguards/injection_ml.py
+++ b/sdk/src/unplug/safeguards/injection_ml.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 
 from unplug.core.config import ScannerConfig
 from unplug.core.context import ExecutionContext
+from unplug.core.ml_band import ML_ABSTAIN_SUBCATEGORY, MlBand, decide_ml_band, max_span_score
 from unplug.core.models import ModelProvider
 from unplug.core.normalize import Normalizer
 from unplug.core.stats import MetricsCollector
@@ -86,6 +87,54 @@ class InjectionSpanScanner(ModelScanner):
         prediction = self._predict(norm.text)
         cfg = self._model.spec.config
         doc_threshold = float(cfg.get("doc_threshold", cfg.get("inj_threshold", 0.5)))
+        span_threshold = float(cfg.get("inj_threshold", 0.5))
+        tau_abstain_low = float(cfg.get("tau_abstain_low", 0.35))
+        abstain_enabled = bool(cfg.get("abstain_enabled", True))
+        span_score = max_span_score(list(prediction.spans))
+
+        band = (
+            decide_ml_band(
+                doc_score=float(prediction.doc_score),
+                span_score=span_score,
+                tau_doc=doc_threshold,
+                tau_span=span_threshold,
+                tau_abstain_low=tau_abstain_low,
+            )
+            if abstain_enabled
+            else MlBand.BLOCK
+            if (float(prediction.doc_score) >= doc_threshold or span_score >= span_threshold)
+            else MlBand.ALLOW
+        )
+
+        if band == MlBand.ALLOW:
+            return
+
+        if band == MlBand.ABSTAIN:
+            yield Finding(
+                category="injection",
+                subcategory=ML_ABSTAIN_SUBCATEGORY,
+                stage="ml_band",
+                span_start=0,
+                span_end=len(text.text),
+                score=max(float(prediction.doc_score), span_score, 0.55),
+                evidence="ML abstain band: uncertain injection signal",
+                replacement="[REDACTED:injection]",
+            )
+            for span in prediction.spans:
+                orig_start, orig_end = norm.to_original_span(span.start, span.end)
+                if orig_end <= orig_start:
+                    continue
+                yield Finding(
+                    category="injection",
+                    subcategory="span_model",
+                    stage="model",
+                    span_start=orig_start,
+                    span_end=orig_end,
+                    score=max(span.score, 0.55),
+                    evidence="Span model flagged uncertain injection region",
+                    replacement="[REDACTED:injection]",
+                )
+            return
 
         for span in prediction.spans:
             orig_start, orig_end = norm.to_original_span(span.start, span.end)

--- a/sdk/tests/test_ml_band.py
+++ b/sdk/tests/test_ml_band.py
@@ -1,0 +1,62 @@
+"""Tests for ML abstain band decision logic."""
+
+from __future__ import annotations
+
+from unplug.api.enums import Action
+from unplug.config.policy import ScanPolicy
+from unplug.core.ml_band import MlBand, decide_ml_band
+from unplug.core.policy import decide_action
+from unplug.models import Finding
+
+_KW = {"tau_doc": 0.9, "tau_span": 0.45, "tau_abstain_low": 0.35}
+
+
+class TestDecideMlBand:
+    def test_block_on_high_doc(self) -> None:
+        band = decide_ml_band(doc_score=0.95, span_score=0.1, **_KW)
+        assert band == MlBand.BLOCK
+
+    def test_block_on_high_span(self) -> None:
+        band = decide_ml_band(doc_score=0.2, span_score=0.8, **_KW)
+        assert band == MlBand.BLOCK
+
+    def test_allow_on_low_scores(self) -> None:
+        band = decide_ml_band(doc_score=0.1, span_score=0.1, **_KW)
+        assert band == MlBand.ALLOW
+
+    def test_abstain_in_middle_band(self) -> None:
+        band = decide_ml_band(doc_score=0.5, span_score=0.2, **_KW)
+        assert band == MlBand.ABSTAIN
+
+
+class TestAbstainPolicy:
+    def test_abstain_action_from_ml_band_finding(self) -> None:
+        findings = [
+            Finding(
+                category="injection",
+                subcategory="ml_abstain_band",
+                stage="ml_band",
+                span_start=0,
+                span_end=10,
+                score=0.6,
+                evidence="uncertain",
+            )
+        ]
+        action = decide_action(findings, text_len=10, policy=ScanPolicy(), risk_score=0.6)
+        assert action == Action.ABSTAIN
+
+    def test_abstain_disabled_falls_through(self) -> None:
+        findings = [
+            Finding(
+                category="injection",
+                subcategory="ml_abstain_band",
+                stage="ml_band",
+                span_start=2,
+                span_end=5,
+                score=0.6,
+                evidence="uncertain",
+            )
+        ]
+        policy = ScanPolicy(abstain_enabled=False)
+        action = decide_action(findings, text_len=100, policy=policy, risk_score=0.6)
+        assert action == Action.REDACT

--- a/sdk/unplug.example.toml
+++ b/sdk/unplug.example.toml
@@ -81,11 +81,17 @@ base_score = 0.90
 # Catalog default: repo_id = "Unplug-AI/unplug-tiny-v1" (see src/unplug/models/catalog.toml)
 # Override only for offline/air-gapped: path = "/path/to/checkpoint"
 
+[policy]
+abstain_enabled = true
+tau_abstain_low = 0.35
+
 [models.tiny.config]
 max_length = 512
 stride = 64
 inj_threshold = 0.45
 doc_threshold = 0.9
+tau_abstain_low = 0.35
+abstain_enabled = true
 device = "auto"
 long_text_mode = "sliding"
 long_text_threshold_chars = 8192


### PR DESCRIPTION
## Summary
- Phase A: pin HF catalog revision, wire `Action.ABSTAIN` + ML band, publish `docs/BENCHMARKS.md`, fix setup-uv `version` key
- Phase B: PR scan workflow + `scripts/scan_pr_files.py`

Sibling repos (separate commits): unplug-mcp 0.2.1, unplug-server 0.2.1, unplug_exp disposition/launcher, unplug-site benchmarks page.

## Test plan
- [x] `make check-ci` green (642 tests)
- [x] unplug-mcp 25 passed, unplug-server 46 passed
- [ ] CI on PR