### PR TITLE
Fix Greptile PR #13 review items

### DIFF
--- a/.github/workflows/pr-scan.yml
+++ b/.github/workflows/pr-scan.yml
@@ -31,4 +31,4 @@ jobs:
         run: uv sync --dev
 
       - name: Scan changed files
-        run: uv run python scripts/scan_pr_files.py --base-ref ${{ github.base_ref }}
+        run: uv run python scripts/scan_pr_files.py --base-ref "${{ github.base_ref }}"

--- a/sdk/scripts/scan_pr_files.py
+++ b/sdk/scripts/scan_pr_files.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Scan changed files in a PR for prompt injection patterns (regex-only Guard)."""
+"""Scan agent config files changed in a PR (regex-only Guard).
+
+Only paths matching AGENTS.md, .cursor/, mcp.json, or claude_desktop_config are
+scanned so docs/tests with attack fixtures do not false-positive the workflow.
+"""
 
 from __future__ import annotations
 

--- a/sdk/src/unplug/core/policy.py
+++ b/sdk/src/unplug/core/policy.py
@@ -69,12 +69,12 @@ def decide_action(
     risk_score: float,
 ) -> Action:
     """Apply document coverage gate then span-level thresholds."""
-    if policy.abstain_enabled and any(f.subcategory == ML_ABSTAIN_SUBCATEGORY for f in findings):
-        return Action.ABSTAIN
     if text_len > 0 and flagged_coverage(text_len, findings, policy) >= policy.block_coverage_ratio:
         return Action.BLOCK
     if risk_score >= policy.block_threshold:
         return Action.BLOCK
+    if policy.abstain_enabled and any(f.subcategory == ML_ABSTAIN_SUBCATEGORY for f in findings):
+        return Action.ABSTAIN
     if any(f.score >= policy.redact_threshold for f in findings):
         return Action.REDACT
     if risk_score >= policy.review_threshold:

--- a/sdk/src/unplug/safeguards/injection_ml.py
+++ b/sdk/src/unplug/safeguards/injection_ml.py
@@ -122,7 +122,7 @@ class InjectionSpanScanner(ModelScanner):
                 subcategory=ML_ABSTAIN_SUBCATEGORY,
                 stage="ml_band",
                 span_start=0,
-                span_end=len(text.text),
+                span_end=0,
                 score=max(float(prediction.doc_score), span_score, 0.55),
                 evidence="ML abstain band: uncertain injection signal",
                 replacement="[REDACTED:injection]",

--- a/sdk/src/unplug/safeguards/injection_ml.py
+++ b/sdk/src/unplug/safeguards/injection_ml.py
@@ -86,10 +86,17 @@ class InjectionSpanScanner(ModelScanner):
         norm = self._normalizer.normalize(text.text)
         prediction = self._predict(norm.text)
         cfg = self._model.spec.config
+        policy = context.scan_policy
         doc_threshold = float(cfg.get("doc_threshold", cfg.get("inj_threshold", 0.5)))
         span_threshold = float(cfg.get("inj_threshold", 0.5))
-        tau_abstain_low = float(cfg.get("tau_abstain_low", 0.35))
-        abstain_enabled = bool(cfg.get("abstain_enabled", True))
+        tau_abstain_low = (
+            policy.tau_abstain_low
+            if policy is not None
+            else float(cfg.get("tau_abstain_low", 0.35))
+        )
+        abstain_enabled = (
+            policy.abstain_enabled if policy is not None else bool(cfg.get("abstain_enabled", True))
+        )
         span_score = max_span_score(list(prediction.spans))
 
         band = (

--- a/sdk/tests/test_ml_band.py
+++ b/sdk/tests/test_ml_band.py
@@ -36,14 +36,29 @@ class TestAbstainPolicy:
                 category="injection",
                 subcategory="ml_abstain_band",
                 stage="ml_band",
-                span_start=2,
-                span_end=5,
+                span_start=0,
+                span_end=0,
                 score=0.6,
                 evidence="uncertain",
             )
         ]
         action = decide_action(findings, text_len=100, policy=ScanPolicy(), risk_score=0.6)
         assert action == Action.ABSTAIN
+
+    def test_abstain_finding_blocks_via_coverage_gate(self) -> None:
+        findings = [
+            Finding(
+                category="injection",
+                subcategory="ml_abstain_band",
+                stage="ml_band",
+                span_start=0,
+                span_end=100,
+                score=0.85,
+                evidence="uncertain but full-document coverage",
+            )
+        ]
+        action = decide_action(findings, text_len=100, policy=ScanPolicy(), risk_score=0.85)
+        assert action == Action.BLOCK
 
     def test_high_risk_abstain_finding_blocks(self) -> None:
         findings = [

--- a/sdk/tests/test_ml_band.py
+++ b/sdk/tests/test_ml_band.py
@@ -36,14 +36,29 @@ class TestAbstainPolicy:
                 category="injection",
                 subcategory="ml_abstain_band",
                 stage="ml_band",
-                span_start=0,
-                span_end=10,
+                span_start=2,
+                span_end=5,
                 score=0.6,
                 evidence="uncertain",
             )
         ]
-        action = decide_action(findings, text_len=10, policy=ScanPolicy(), risk_score=0.6)
+        action = decide_action(findings, text_len=100, policy=ScanPolicy(), risk_score=0.6)
         assert action == Action.ABSTAIN
+
+    def test_high_risk_abstain_finding_blocks(self) -> None:
+        findings = [
+            Finding(
+                category="injection",
+                subcategory="ml_abstain_band",
+                stage="ml_band",
+                span_start=2,
+                span_end=5,
+                score=0.85,
+                evidence="uncertain but high doc score",
+            )
+        ]
+        action = decide_action(findings, text_len=100, policy=ScanPolicy(), risk_score=0.85)
+        assert action == Action.BLOCK
 
     def test_abstain_disabled_falls_through(self) -> None:
         findings = [


### PR DESCRIPTION
## Summary
- Reorder `decide_action` so coverage gate and `block_threshold` run before ABSTAIN (high-risk uncertain ML signals now BLOCK)
- Wire `ScanPolicy.tau_abstain_low` / `abstain_enabled` into `InjectionSpanScanner` via `context.scan_policy`
- Quote `github.base_ref` in PR scan workflow; document agent-config-only scan scope

## Test plan
- [x] `uv run pytest tests/test_ml_band.py -v`
- [x] `uv run ruff check` on touched files