### PR TITLE
Audit follow-ups: strict allowlist and hardening

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -211,6 +211,8 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for layering and optional extra
 
 ## Development
 
+Supported Python versions: **3.11, 3.12, and 3.13** (CI matrix). On 3.13, the `ml` and `litellm` extras are skipped in CI until `tokenizers` publishes cp313 wheels; regex-only core and optional `presidio`/`yara`/`haystack` tests still run. Mark optional tests with `@pytest.mark.requires_ml`, `requires_presidio`, or `requires_yara`.
+
 ```bash
 cd sdk && uv sync --all-extras --dev
 

--- a/sdk/src/unplug/client.py
+++ b/sdk/src/unplug/client.py
@@ -79,8 +79,12 @@ class UnplugClient:
         return self.scan_request(request)
 
     def scan_request(self, request: ScanRequest) -> ScanResult:
-        data = self._post_json("/v1/scan", request.model_dump(mode="json"))
-        return ScanResult.model_validate(data)
+        try:
+            data = self._post_json("/v1/scan", request.model_dump(mode="json"))
+            return ScanResult.model_validate(data)
+        except ValueError as exc:
+            msg = f"Unplug server returned invalid JSON: {exc}"
+            raise ServerError(msg) from exc
 
     def scan_output(
         self,

--- a/sdk/src/unplug/client.py
+++ b/sdk/src/unplug/client.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import os
 import warnings
 from typing import Self
 from urllib.parse import urlparse
 
 import httpx
+from pydantic import ValidationError
 
 from unplug.api.enums import Source
 from unplug.api.types import BatchScanRequest, ScanRequest, ScanResult
@@ -53,9 +55,20 @@ class UnplugClient:
         try:
             response = self._client.post(path, json=payload)
             response.raise_for_status()
-            return response.json()
+            try:
+                return response.json()
+            except json.JSONDecodeError as exc:
+                msg = f"Unplug server returned malformed JSON: {exc}"
+                raise ServerError(msg) from exc
         except httpx.HTTPError as exc:
             msg = f"Unplug server request failed: {type(exc).__name__}: {exc}"
+            raise ServerError(msg) from exc
+
+    def _parse_scan_result(self, data: object) -> ScanResult:
+        try:
+            return ScanResult.model_validate(data)
+        except ValidationError as exc:
+            msg = f"Unplug server returned invalid scan response: {exc}"
             raise ServerError(msg) from exc
 
     def _get_json(self, path: str) -> dict:
@@ -79,12 +92,8 @@ class UnplugClient:
         return self.scan_request(request)
 
     def scan_request(self, request: ScanRequest) -> ScanResult:
-        try:
-            data = self._post_json("/v1/scan", request.model_dump(mode="json"))
-            return ScanResult.model_validate(data)
-        except ValueError as exc:
-            msg = f"Unplug server returned invalid JSON: {exc}"
-            raise ServerError(msg) from exc
+        data = self._post_json("/v1/scan", request.model_dump(mode="json"))
+        return self._parse_scan_result(data)
 
     def scan_output(
         self,
@@ -103,12 +112,12 @@ class UnplugClient:
 
     def scan_output_request(self, request: ScanRequest) -> ScanResult:
         data = self._post_json("/v1/scan/output", request.model_dump(mode="json"))
-        return ScanResult.model_validate(data)
+        return self._parse_scan_result(data)
 
     def batch_scan(self, items: list[ScanRequest]) -> list[ScanResult]:
         request = BatchScanRequest(items=items)
         data = self._post_json("/v1/batch", request.model_dump(mode="json"))
-        return [ScanResult.model_validate(r) for r in data["results"]]
+        return [self._parse_scan_result(r) for r in data["results"]]
 
     def health(self) -> dict[str, object]:
         return self._get_json("/v1/health")

--- a/sdk/src/unplug/config/guard.py
+++ b/sdk/src/unplug/config/guard.py
@@ -24,12 +24,21 @@ from unplug.config.tools import ToolPolicyConfig
 MANDATORY_INPUT_SCANNERS: frozenset[str] = frozenset({"injection", "destructive"})
 
 
-def resolve_input_scanners(requested: list[str] | None) -> list[str] | None:
+def resolve_input_scanners(
+    requested: list[str] | None,
+    *,
+    strict: bool = False,
+) -> list[str] | None:
     """Union mandatory input scanners; never allow dropping injection/destructive."""
     if requested is None:
         return None
-    merged = list(dict.fromkeys([*requested, *sorted(MANDATORY_INPUT_SCANNERS)]))
     omitted = MANDATORY_INPUT_SCANNERS - set(requested)
+    if omitted and strict:
+        from unplug.exceptions import ConfigError
+
+        msg = f"scan request omitted mandatory scanners: {', '.join(sorted(omitted))}"
+        raise ConfigError(msg)
+    merged = list(dict.fromkeys([*requested, *sorted(MANDATORY_INPUT_SCANNERS)]))
     if omitted:
         from unplug.core.runtime.logging import get_logger
 
@@ -81,6 +90,10 @@ class GuardConfig(BaseModel):
 
     scanners: list[str] = Field(
         default_factory=lambda: ["injection", "destructive", "leakage", "harmful", "urls"]
+    )
+    strict_scanner_allowlist: bool = Field(
+        default=False,
+        description="Raise ConfigError when scan_request omits mandatory input scanners",
     )
     mode: str = "local"
     server_url: str | None = None

--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -33,6 +33,7 @@ from unplug.core.runtime.model_runtime import (
 from unplug.core.runtime.stats import MetricsCollector
 from unplug.core.runtime.versions import MODEL_VERSION_LOCAL, NORMALIZER_VERSION
 from unplug.core.taint import TaintedText, TrustLevel
+from unplug.exceptions import ConfigError
 from unplug.pipelines.input import InputPipeline
 from unplug.pipelines.output import OutputPipeline
 from unplug.pipelines.toolcall import ToolCallPipeline
@@ -636,6 +637,8 @@ class Guard:
                 if not isolated:
                     self._maybe_mark_session_tainted_from_scan(request.source)
                 return result
+        except ConfigError:
+            raise
         except Exception as exc:
             _log.error("guard.scan_request failed: %s", exc)
             return _fail_closed(exc)

--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -626,7 +626,10 @@ class Guard:
                     return self._server_client.scan_request(request)
                 ctx = self._request_context(request, isolated=isolated)
                 if request.scanners:
-                    ctx.allowed_scanners = resolve_input_scanners(list(request.scanners))
+                    ctx.allowed_scanners = resolve_input_scanners(
+                        list(request.scanners),
+                        strict=self._config.strict_scanner_allowlist,
+                    )
                 if not isolated:
                     self._capture_user_intent(request)
                 result = self._run_input_with_cache(request, ctx)

--- a/sdk/src/unplug/pipelines/input.py
+++ b/sdk/src/unplug/pipelines/input.py
@@ -148,8 +148,17 @@ class InputPipeline(BasePipeline):
         if not has_abstain and (risk < self._judge_low or risk >= self._judge_high):
             return []
         judge_ctx = JudgeContext(scanner_findings=findings)
+        policy = context.scan_policy or self._config.policy
+        judge_text = input_data.text
+        if findings:
+            from unplug.core.redaction import apply_span_redactions
+
+            judge_policy = policy.model_copy(update={"redact_threshold": 0.0})
+            redacted = apply_span_redactions(input_data.text, findings, judge_policy)
+            if redacted is not None:
+                judge_text = redacted
         try:
-            result = run_coroutine_sync(self._judge.judge(input_data.text, judge_ctx))
+            result = run_coroutine_sync(self._judge.judge(judge_text, judge_ctx))
         except Exception as exc:
             _log.error("input pipeline judge failed: %s", exc)
             return [

--- a/sdk/src/unplug/scanners/urls.py
+++ b/sdk/src/unplug/scanners/urls.py
@@ -12,6 +12,7 @@ from collections.abc import Generator
 
 from unplug.core.config import ScannerConfig
 from unplug.core.context import ExecutionContext
+from unplug.core.normalize import EVASION_ONLY_STAGES, Normalizer
 from unplug.core.pattern_loader import load_compiled_patterns
 from unplug.core.runtime.stats import MetricsCollector
 from unplug.core.taint import TaintedText, TrustLevel
@@ -31,6 +32,7 @@ _SCORES: dict[str, float] = {
 }
 
 _DEFAULT_CONFIG = default_scanner_config("urls")
+_RAW_TEXT_SUBCATEGORIES = frozenset({"homoglyph_host", "punycode_host"})
 
 
 class MaliciousUrlScanner(RegexScanner):
@@ -45,6 +47,7 @@ class MaliciousUrlScanner(RegexScanner):
         metrics: MetricsCollector | None = None,
     ) -> None:
         super().__init__(config=config or _DEFAULT_CONFIG, metrics=metrics)
+        self._normalizer = Normalizer(stages=EVASION_ONLY_STAGES)
 
     def _should_scan(self, text: TaintedText) -> bool:
         # URLs typed by the user are routine; hostile links arrive through
@@ -57,10 +60,17 @@ class MaliciousUrlScanner(RegexScanner):
         )
 
     def _scan(self, text: TaintedText, context: ExecutionContext) -> Generator[Finding, None, None]:
+        norm_result = self._normalizer.normalize(text.text)
+        normalized = norm_result.text
         seen: set[tuple[int, int]] = set()
         for subcategory, pattern in self._patterns:
-            for match in pattern.finditer(text.text):
-                span = (match.start(), match.end())
+            corpus = text.text if subcategory in _RAW_TEXT_SUBCATEGORIES else normalized
+            for match in pattern.finditer(corpus):
+                if subcategory in _RAW_TEXT_SUBCATEGORIES:
+                    span_start, span_end = match.start(), match.end()
+                else:
+                    span_start, span_end = norm_result.to_original_span(match.start(), match.end())
+                span = (span_start, span_end)
                 if span in seen:
                     continue
                 seen.add(span)

--- a/sdk/tests/integration/test_client.py
+++ b/sdk/tests/integration/test_client.py
@@ -96,3 +96,15 @@ class TestUnplugClient:
             client = UnplugClient(base_url="http://test:8000")
             with pytest.raises(ServerError, match="Unplug server request failed"):
                 client.scan("hello")
+
+    def test_malformed_json_raises_server_error(self):
+        from unplug.exceptions import ServerError
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"not": "a scan result"}
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(httpx.Client, "post", return_value=mock_resp):
+            client = UnplugClient(base_url="http://localhost:8000")
+            with pytest.raises(ServerError, match="invalid JSON"):
+                client.scan("hello")

--- a/sdk/tests/integration/test_client.py
+++ b/sdk/tests/integration/test_client.py
@@ -97,7 +97,7 @@ class TestUnplugClient:
             with pytest.raises(ServerError, match="Unplug server request failed"):
                 client.scan("hello")
 
-    def test_malformed_json_raises_server_error(self):
+    def test_invalid_scan_response_raises_server_error(self):
         from unplug.exceptions import ServerError
 
         mock_resp = MagicMock()
@@ -106,5 +106,19 @@ class TestUnplugClient:
 
         with patch.object(httpx.Client, "post", return_value=mock_resp):
             client = UnplugClient(base_url="http://localhost:8000")
-            with pytest.raises(ServerError, match="invalid JSON"):
+            with pytest.raises(ServerError, match="invalid scan response"):
+                client.scan("hello")
+
+    def test_malformed_json_raises_server_error(self):
+        import json
+
+        from unplug.exceptions import ServerError
+
+        mock_resp = MagicMock()
+        mock_resp.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(httpx.Client, "post", return_value=mock_resp):
+            client = UnplugClient(base_url="http://localhost:8000")
+            with pytest.raises(ServerError, match="malformed JSON"):
                 client.scan("hello")

--- a/sdk/tests/unit/config/test_strict_scanner_allowlist.py
+++ b/sdk/tests/unit/config/test_strict_scanner_allowlist.py
@@ -1,0 +1,20 @@
+"""strict_scanner_allowlist raises when mandatory scanners omitted."""
+
+from __future__ import annotations
+
+import pytest
+
+from unplug.config.guard import resolve_input_scanners
+from unplug.exceptions import ConfigError
+
+
+def test_strict_raises_on_omitted_mandatory() -> None:
+    with pytest.raises(ConfigError, match="injection"):
+        resolve_input_scanners(["harmful"], strict=True)
+
+
+def test_non_strict_unions_mandatory() -> None:
+    merged = resolve_input_scanners(["harmful"], strict=False)
+    assert merged is not None
+    assert "injection" in merged
+    assert "destructive" in merged

--- a/sdk/tests/unit/config/test_strict_scanner_allowlist.py
+++ b/sdk/tests/unit/config/test_strict_scanner_allowlist.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import pytest
 
-from unplug.config.guard import resolve_input_scanners
+from unplug import Guard
+from unplug.config.guard import GuardConfig, resolve_input_scanners
 from unplug.exceptions import ConfigError
+from unplug.models import ScanRequest
 
 
 def test_strict_raises_on_omitted_mandatory() -> None:
@@ -18,3 +20,9 @@ def test_non_strict_unions_mandatory() -> None:
     assert merged is not None
     assert "injection" in merged
     assert "destructive" in merged
+
+
+def test_guard_strict_allowlist_propagates_config_error() -> None:
+    guard = Guard(config=GuardConfig(strict_scanner_allowlist=True))
+    with pytest.raises(ConfigError, match="injection"):
+        guard.scan_request(ScanRequest(text="hello", scanners=["harmful"]))

--- a/sdk/tests/unit/test_optional_scanner_init.py
+++ b/sdk/tests/unit/test_optional_scanner_init.py
@@ -1,0 +1,21 @@
+"""Guard init validates optional scanner extras."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from unplug.exceptions import ConfigError
+from unplug.guard import Guard
+
+
+def test_pii_without_presidio_raises() -> None:
+    with (
+        patch(
+            "unplug.optional.presidio.get_analyzer_engine_class",
+            side_effect=ImportError("missing"),
+        ),
+        pytest.raises(ConfigError, match="presidio"),
+    ):
+        Guard(scanners=["injection", "pii"])


### PR DESCRIPTION
## Summary
- Add `strict_scanner_allowlist` config to raise `ConfigError` when scan requests omit mandatory input scanners
- URL scanner runs evasion normalize before match; homoglyph/punycode patterns still scan raw text
- Judge receives redacted findings text before BYOLLM call
- Client maps malformed server JSON to `ServerError`
- README documents Python 3.13 CI matrix and pytest markers

## Test plan
- [x] `cd sdk && make check-ci` (790+ tests)
- [x] New tests: strict allowlist, optional scanner init, client malformed JSON