### PR TITLE
Audit 6.6: model cache verification and judge sanitization

### DIFF
--- a/sdk/src/unplug/core/judge.py
+++ b/sdk/src/unplug/core/judge.py
@@ -79,9 +79,10 @@ class CallableJudge:
         self._prompt_template = prompt_template
 
     async def judge(self, text: str, context: JudgeContext) -> JudgeResult:
+        safe_context = self._sanitize_context(context)
         prompt = self._prompt_template.format(
             text=text,
-            context=self._format_context(context),
+            context=self._format_context(safe_context),
         )
         try:
             raw = await asyncio.wait_for(self._fn(prompt), timeout=self._timeout)
@@ -102,6 +103,14 @@ class CallableJudge:
                 score=1.0,
                 reason=f"Judge failed: {type(exc).__name__}",
             )
+
+    def _sanitize_context(self, context: JudgeContext) -> JudgeContext:
+        if not context.scanner_findings:
+            return context
+        redacted = [
+            finding.model_copy(update={"evidence": ""}) for finding in context.scanner_findings
+        ]
+        return context.model_copy(update={"scanner_findings": redacted})
 
     def _format_context(self, context: JudgeContext) -> str:
         parts = []

--- a/sdk/src/unplug/ml/store.py
+++ b/sdk/src/unplug/ml/store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -15,6 +16,13 @@ from unplug.exceptions import ConfigError
 from unplug.ml.catalog import CatalogTier, load_catalog
 from unplug.ml.models import ModelSpec
 from unplug.optional.ml import require_huggingface_hub
+
+
+def _config_digest(path: Path) -> str | None:
+    config = path / "config.json"
+    if not config.is_file():
+        return None
+    return hashlib.sha256(config.read_bytes()).hexdigest()[:16]
 
 
 def default_cache_root() -> Path:
@@ -33,6 +41,7 @@ class ModelManifest(BaseModel):
     repo_id: str
     revision: str
     path: str
+    config_digest: str | None = None
     installed_at: str = Field(default_factory=lambda: datetime.now(tz=UTC).isoformat())
 
 
@@ -68,14 +77,24 @@ class ModelStore:
         )
 
     def resolve_local_path(self, tier: str) -> Path | None:
-        """Return cached checkpoint dir if manifest + config.json exist."""
+        """Return cached checkpoint dir if manifest + config.json exist and match catalog."""
         manifest = self.read_manifest(tier)
         if manifest is None:
             return None
         ckpt = Path(manifest.path)
-        if ckpt.is_dir() and (ckpt / "config.json").is_file():
-            return ckpt
-        return None
+        if not ckpt.is_dir() or not (ckpt / "config.json").is_file():
+            return None
+
+        cat = load_catalog()
+        entry = cat.get(tier)
+        if entry is not None and manifest.revision != entry.revision:
+            return None
+
+        digest = _config_digest(ckpt)
+        if manifest.config_digest is not None and digest != manifest.config_digest:
+            return None
+
+        return ckpt
 
     def is_valid_checkpoint(self, path: Path) -> bool:
         return path.is_dir() and (path / "config.json").is_file()
@@ -126,6 +145,7 @@ class ModelStore:
                 repo_id=tier_entry.repo_id,
                 revision=tier_entry.revision,
                 path=str(ckpt),
+                config_digest=_config_digest(ckpt),
             )
         )
         return ckpt

--- a/sdk/tests/unit/core/test_judge.py
+++ b/sdk/tests/unit/core/test_judge.py
@@ -112,6 +112,36 @@ class TestCallableJudge:
         result = await judge.judge("hello", JudgeContext())
         assert result.action == Action.ALLOW
 
+    @pytest.mark.asyncio
+    async def test_scanner_evidence_not_sent_to_llm(self):
+        captured: list[str] = []
+
+        async def capture_llm(prompt: str) -> str:
+            captured.append(prompt)
+            return json.dumps(
+                {
+                    "action": "review",
+                    "category": "injection",
+                    "score": 0.5,
+                    "reason": "borderline",
+                }
+            )
+
+        finding = Finding(
+            category="leakage",
+            subcategory="api_key",
+            stage="regex",
+            span_start=0,
+            span_end=20,
+            score=0.8,
+            evidence="sk-secret-should-not-leak",
+        )
+        judge = CallableJudge(capture_llm)
+        await judge.judge("hello", JudgeContext(scanner_findings=[finding]))
+        assert captured
+        assert "sk-secret-should-not-leak" not in captured[0]
+        assert "leakage" in captured[0]
+
     def test_implements_protocol(self):
         async def noop(prompt: str) -> str:
             return "{}"

--- a/sdk/tests/unit/ml/test_model_store.py
+++ b/sdk/tests/unit/ml/test_model_store.py
@@ -36,10 +36,54 @@ def test_store_manifest_roundtrip(tmp_path: Path) -> None:
     from unplug.ml.store import ModelManifest
 
     store.write_manifest(
-        ModelManifest(tier="tiny", repo_id="Unplug-AI/test", revision="main", path=str(ckpt))
+        ModelManifest(
+            tier="tiny",
+            repo_id="Unplug-AI/test",
+            revision=load_catalog().tiers["tiny"].revision,
+            path=str(ckpt),
+            config_digest="abc123",
+        )
     )
     resolved = store.resolve_local_path("tiny")
-    assert resolved == ckpt
+    assert resolved is None
+
+
+def test_store_rejects_stale_catalog_revision(tmp_path: Path) -> None:
+    store = ModelStore(cache_root=tmp_path)
+    ckpt = tmp_path / "tiny" / "checkpoint"
+    ckpt.mkdir(parents=True)
+    (ckpt / "config.json").write_text("{}", encoding="utf-8")
+    from unplug.ml.store import ModelManifest
+
+    store.write_manifest(
+        ModelManifest(
+            tier="tiny",
+            repo_id="Unplug-AI/test",
+            revision="stale-revision",
+            path=str(ckpt),
+        )
+    )
+    assert store.resolve_local_path("tiny") is None
+
+
+def test_store_accepts_matching_revision_and_digest(tmp_path: Path) -> None:
+    store = ModelStore(cache_root=tmp_path)
+    ckpt = tmp_path / "tiny" / "checkpoint"
+    ckpt.mkdir(parents=True)
+    (ckpt / "config.json").write_text('{"model": "test"}', encoding="utf-8")
+    from unplug.ml.store import ModelManifest, _config_digest
+
+    digest = _config_digest(ckpt)
+    store.write_manifest(
+        ModelManifest(
+            tier="tiny",
+            repo_id="Unplug-AI/test",
+            revision=load_catalog().tiers["tiny"].revision,
+            path=str(ckpt),
+            config_digest=digest,
+        )
+    )
+    assert store.resolve_local_path("tiny") == ckpt
 
 
 def test_env_path_overrides_cache(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Reject cached checkpoints when manifest revision differs from bundled catalog or `config.json` digest mismatches
- Store `config_digest` in manifest on download
- Strip scanner finding evidence before BYOLLM judge prompts (defense in depth alongside input pipeline redaction)

## Test plan
- [x] `cd sdk && make check-ci`
- [x] New tests: stale revision, digest mismatch, judge evidence not in prompt