### PR TITLE
Phase B: GitHub scan action, Greptile fixes, unplug-scan-pr CLI

### DIFF
--- a/.github/actions/unplug-scan/README.md
+++ b/.github/actions/unplug-scan/README.md
@@ -1,0 +1,54 @@
+# Unplug PR agent scan (composite action)
+
+Scan **agent-related files changed in a PR** with the unplug-ai regex Guard. Intended for repos that ship `AGENTS.md`, `.cursor/rules`, or MCP client configs.
+
+## Usage in this repo
+
+Already wired in [`.github/workflows/pr-scan.yml`](../workflows/pr-scan.yml).
+
+## Usage in another repository
+
+```yaml
+jobs:
+  unplug-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: UnplugAI/Unplug/.github/actions/unplug-scan@dev
+        with:
+          base-ref: main
+          install-mode: pypi
+          unplug-version: ">=0.3.0"
+```
+
+## Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `base-ref` | `dev` | Base branch for `git diff origin/<base-ref>...HEAD` |
+| `python-version` | `3.12` | Python version |
+| `working-directory` | `sdk` | Path to SDK tree when `install-mode: local` |
+| `install-mode` | `local` | `local` (uv sync) or `pypi` (install from PyPI) |
+| `unplug-version` | `>=0.3.0` | Version constraint for PyPI install |
+
+## What gets scanned
+
+Files matching any of:
+
+- `AGENTS.md` / `AGENT.md`
+- `.cursor/` (rules, hooks, MCP config)
+- `mcp.json`, `claude_desktop_config`
+
+Test fixtures, docs, and `.github/` paths are skipped automatically.
+
+## Local CLI
+
+```bash
+pip install unplug-ai
+unplug-scan-pr --base-ref dev
+```

--- a/.github/actions/unplug-scan/action.yml
+++ b/.github/actions/unplug-scan/action.yml
@@ -1,0 +1,60 @@
+name: Unplug PR agent scan
+description: Scan changed agent/MCP config files with unplug-ai (regex-only Guard)
+
+inputs:
+  base-ref:
+    description: Base branch name for git diff (e.g. dev or main)
+    required: false
+    default: dev
+  python-version:
+    description: Python version for the scan job
+    required: false
+    default: "3.12"
+  working-directory:
+    description: Directory containing pyproject.toml for unplug-ai (sdk/ in this repo)
+    required: false
+    default: sdk
+  install-mode:
+    description: "local = uv sync in working-directory; pypi = pip install unplug-ai"
+    required: false
+    default: local
+  unplug-version:
+    description: PyPI version constraint when install-mode is pypi
+    required: false
+    default: ">=0.3.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        version: "0.6.14"
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install unplug-ai (local dev tree)
+      if: inputs.install-mode == 'local'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: uv sync --all-extras --dev
+
+    - name: Install unplug-ai (PyPI)
+      if: inputs.install-mode == 'pypi'
+      shell: bash
+      run: uv pip install --system "unplug-ai${{ inputs.unplug-version }}"
+
+    - name: Scan changed agent files
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ "${{ inputs.install-mode }}" = "local" ]; then
+          cd "${{ inputs.working-directory }}"
+          uv run unplug-scan-pr --base-ref "${{ inputs.base-ref }}" --repo-root "$(git rev-parse --show-toplevel)"
+        else
+          unplug-scan-pr --base-ref "${{ inputs.base-ref }}" --repo-root "$(git rev-parse --show-toplevel)"
+        fi

--- a/.github/workflows/pr-scan.yml
+++ b/.github/workflows/pr-scan.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   scan:

--- a/.github/workflows/pr-scan.yml
+++ b/.github/workflows/pr-scan.yml
@@ -3,32 +3,38 @@ name: PR agent scan
 on:
   pull_request:
     branches: [dev]
+  workflow_dispatch:
+    inputs:
+      base-ref:
+        description: Base branch for diff
+        required: false
+        default: dev
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   scan:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: sdk
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v7
+      - name: Run Unplug agent file scan
+        uses: ./.github/actions/unplug-scan
         with:
-          enable-cache: true
-          version: "0.6.14"
+          base-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.base-ref || github.base_ref }}
+          install-mode: local
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install SDK
-        run: uv sync --all-extras --dev
-
-      - name: Scan changed files
-        run: uv run python scripts/scan_pr_files.py --base-ref "${{ github.base_ref }}"
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "### Unplug PR agent scan"
+            echo ""
+            echo "- Base ref: \`${{ github.event_name == 'workflow_dispatch' && inputs.base-ref || github.base_ref }}\`"
+            echo "- Mode: regex-only Guard (no ML download)"
+            echo "- Scanned paths: AGENTS.md, .cursor/, MCP configs"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/reusable-agent-scan.yml
+++ b/.github/workflows/reusable-agent-scan.yml
@@ -1,0 +1,37 @@
+name: Reusable agent scan
+
+on:
+  workflow_call:
+    inputs:
+      base-ref:
+        description: Base branch for git diff
+        required: false
+        type: string
+        default: dev
+      install-mode:
+        description: local (monorepo SDK) or pypi
+        required: false
+        type: string
+        default: pypi
+      unplug-version:
+        description: PyPI version when install-mode is pypi
+        required: false
+        type: string
+        default: ">=0.3.0"
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/unplug-scan
+        with:
+          base-ref: ${{ inputs.base-ref }}
+          install-mode: ${{ inputs.install-mode }}
+          unplug-version: ${{ inputs.unplug-version }}

--- a/sdk/docs/BENCHMARKS.md
+++ b/sdk/docs/BENCHMARKS.md
@@ -37,4 +37,12 @@ Per-holdout metrics for `unplug-tiny-v1` live on the [model card](https://huggin
 
 ## CI
 
-PRs run `.github/workflows/pr-scan.yml` (regex scan on changed agent-related files).
+PRs to `dev` run:
+
+| Workflow | Purpose |
+|----------|---------|
+| [`ci.yml`](../../.github/workflows/ci.yml) | Lint + pytest matrix (3.11–3.13) |
+| [`pr-scan.yml`](../../.github/workflows/pr-scan.yml) | Regex scan on changed agent/MCP config files |
+| [`reusable-agent-scan.yml`](../../.github/workflows/reusable-agent-scan.yml) | `workflow_call` entry for other repos |
+
+Other repositories can reuse the scan via the composite action [`.github/actions/unplug-scan`](../../.github/actions/unplug-scan/) or `unplug-scan-pr` CLI from PyPI.

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -140,6 +140,7 @@ filterwarnings = [
 unplug-audit = "unplug.cli.audit:main"
 unplug-models = "unplug.cli.models:main"
 unplug-sidecar = "unplug.cli.sidecar:main"
+unplug-scan-pr = "unplug.cli.scan_pr:main"
 
 [dependency-groups]
 dev = [

--- a/sdk/scripts/scan_pr_files.py
+++ b/sdk/scripts/scan_pr_files.py
@@ -1,77 +1,18 @@
 #!/usr/bin/env python3
-"""Scan agent config files changed in a PR (regex-only Guard).
-
-Only paths matching AGENTS.md, .cursor/, mcp.json, or claude_desktop_config are
-scanned so docs/tests with attack fixtures do not false-positive the workflow.
-"""
+"""Backward-compatible wrapper for unplug.cli.scan_pr."""
 
 from __future__ import annotations
 
-import argparse
-import subprocess
 import sys
 from pathlib import Path
 
-from unplug import Guard
-from unplug.api.enums import Action
+if __name__ == "__main__" and __package__ is None:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-_SKIP_PREFIXES = (
-    "sdk/tests/",
-    "sdk/benchmarks/",
-    "sdk/docs/",
-    "sdk/examples/",
-    "sdk/demo/",
-    ".github/",
-    ".context/",
-)
-_AGENT_MARKERS = ("AGENTS.md", ".cursor/", "mcp.json", "claude_desktop_config")
-_MAX_CHUNK = 2000
-
-
-def _changed_files(base_ref: str, repo_root: Path) -> list[Path]:
-    out = subprocess.check_output(
-        ["git", "diff", "--name-only", "--diff-filter=ACMRT", f"origin/{base_ref}...HEAD"],
-        cwd=repo_root,
-        text=True,
-    )
-    paths: list[Path] = []
-    for line in out.splitlines():
-        rel = line.strip()
-        if not rel or any(rel.startswith(p) for p in _SKIP_PREFIXES):
-            continue
-        path = repo_root / rel
-        if not path.is_file():
-            continue
-        rel_posix = rel.replace("\\", "/")
-        if any(marker in rel_posix for marker in _AGENT_MARKERS):
-            paths.append(path)
-    return paths
-
-
-def _chunks(text: str) -> list[str]:
-    text = text[:50_000]
-    return [text[i : i + _MAX_CHUNK] for i in range(0, len(text), _MAX_CHUNK)] or [text]
-
-
-def main() -> int:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--base-ref", default="main")
-    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
-    args = parser.parse_args()
-
-    guard = Guard()
-    blocked = 0
-    for path in _changed_files(args.base_ref, args.repo_root):
-        rel = path.relative_to(args.repo_root)
-        for chunk in _chunks(path.read_text(encoding="utf-8", errors="replace")):
-            result = guard.scan(chunk, source="user")
-            if result.action == Action.BLOCK or not result.safe:
-                msg = f"Unplug flagged {result.action.value} (risk={result.risk_score:.2f})"
-                print(f"::error file={rel}::{msg}")
-                blocked += 1
-                break
-    return 1 if blocked else 0
-
+from unplug.cli.scan_pr import main
 
 if __name__ == "__main__":
+    repo_root = Path(__file__).resolve().parents[2]
+    if "--repo-root" not in sys.argv:
+        sys.argv[1:1] = ["--repo-root", str(repo_root)]
     sys.exit(main())

--- a/sdk/src/unplug/cli/scan_pr.py
+++ b/sdk/src/unplug/cli/scan_pr.py
@@ -1,0 +1,115 @@
+"""CLI: unplug-scan-pr — regex Guard scan on agent config files changed in a PR."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from unplug import Guard
+from unplug.api.enums import Action
+
+_SKIP_PREFIXES = (
+    "sdk/tests/",
+    "tests/",
+    "benchmarks/",
+    "docs/",
+    "examples/",
+    "demo/",
+    ".github/",
+    ".context/",
+)
+_AGENT_MARKERS = (
+    "AGENTS.md",
+    "AGENT.md",
+    ".cursor/",
+    "mcp.json",
+    "claude_desktop_config",
+    ".mcp/",
+)
+_MAX_CHUNK = 2000
+
+
+def changed_agent_files(base_ref: str, repo_root: Path) -> list[Path]:
+    """Return changed files that look like agent/MCP configuration."""
+    out = subprocess.check_output(
+        ["git", "diff", "--name-only", "--diff-filter=ACMRT", f"origin/{base_ref}...HEAD"],
+        cwd=repo_root,
+        text=True,
+    )
+    paths: list[Path] = []
+    for line in out.splitlines():
+        rel = line.strip()
+        if not rel or any(rel.startswith(p) for p in _SKIP_PREFIXES):
+            continue
+        path = repo_root / rel
+        if not path.is_file():
+            continue
+        rel_posix = rel.replace("\\", "/")
+        if any(marker in rel_posix for marker in _AGENT_MARKERS):
+            paths.append(path)
+    return paths
+
+
+def _chunks(text: str) -> list[str]:
+    text = text[:50_000]
+    return [text[i : i + _MAX_CHUNK] for i in range(0, len(text), _MAX_CHUNK)] or [text]
+
+
+def scan_paths(repo_root: Path, paths: list[Path]) -> list[tuple[Path, str]]:
+    """Scan files; return list of (path, message) for each blocked chunk."""
+    guard = Guard()
+    blocked: list[tuple[Path, str]] = []
+    for path in paths:
+        for chunk in _chunks(path.read_text(encoding="utf-8", errors="replace")):
+            result = guard.scan(chunk, source="user")
+            if result.action == Action.BLOCK or not result.safe:
+                rel = path.relative_to(repo_root)
+                msg = f"Unplug flagged {result.action.value} (risk={result.risk_score:.2f})"
+                blocked.append((rel, msg))
+                break
+    return blocked
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Scan agent-related files changed in a PR with unplug-ai (regex-only)",
+    )
+    parser.add_argument("--base-ref", default="dev", help="Base branch name (default: dev)")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: cwd)",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        type=Path,
+        help="Explicit file paths to scan (skips git diff when set)",
+    )
+    args = parser.parse_args()
+    repo_root = args.repo_root.resolve()
+
+    if args.paths:
+        paths = [p if p.is_absolute() else repo_root / p for p in args.paths]
+    else:
+        paths = changed_agent_files(args.base_ref, repo_root)
+
+    if not paths:
+        print("No agent-related files to scan.")
+        return 0
+
+    blocked = scan_paths(repo_root, paths)
+    for rel, msg in blocked:
+        print(f"::error file={rel}::{msg}")
+    if blocked:
+        print(f"\n{len(blocked)} file(s) flagged by Unplug PR scan.")
+        return 1
+    print(f"Scanned {len(paths)} agent-related file(s); no issues found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdk/src/unplug/cli/scan_pr.py
+++ b/sdk/src/unplug/cli/scan_pr.py
@@ -65,7 +65,10 @@ def scan_paths(repo_root: Path, paths: list[Path]) -> list[tuple[Path, str]]:
         for chunk in _chunks(path.read_text(encoding="utf-8", errors="replace")):
             result = guard.scan(chunk, source="user")
             if result.action == Action.BLOCK or not result.safe:
-                rel = path.relative_to(repo_root)
+                try:
+                    rel = path.relative_to(repo_root)
+                except ValueError:
+                    rel = path
                 msg = f"Unplug flagged {result.action.value} (risk={result.risk_score:.2f})"
                 blocked.append((rel, msg))
                 break

--- a/sdk/src/unplug/client.py
+++ b/sdk/src/unplug/client.py
@@ -114,10 +114,20 @@ class UnplugClient:
         data = self._post_json("/v1/scan/output", request.model_dump(mode="json"))
         return self._parse_scan_result(data)
 
+    def _parse_batch_results(self, data: dict[str, object]) -> list[ScanResult]:
+        raw = data.get("results")
+        if raw is None:
+            msg = "Unplug server returned invalid batch response: missing 'results' key"
+            raise ServerError(msg)
+        if not isinstance(raw, list):
+            msg = "Unplug server returned invalid batch response: 'results' must be a list"
+            raise ServerError(msg)
+        return [self._parse_scan_result(item) for item in raw]
+
     def batch_scan(self, items: list[ScanRequest]) -> list[ScanResult]:
         request = BatchScanRequest(items=items)
         data = self._post_json("/v1/batch", request.model_dump(mode="json"))
-        return [self._parse_scan_result(r) for r in data["results"]]
+        return self._parse_batch_results(data)
 
     def health(self) -> dict[str, object]:
         return self._get_json("/v1/health")

--- a/sdk/src/unplug/scanners/leakage.py
+++ b/sdk/src/unplug/scanners/leakage.py
@@ -44,8 +44,10 @@ class LeakageScanner(RegexScanner):
         if text.trust_level == TrustLevel.TRUSTED:
             return []
         if text.trust_level == TrustLevel.USER:
-            policy = context.scan_policy
-            if policy is None or not policy.scan_user_secrets:
+            from unplug.config.policy import ScanPolicy
+
+            policy = context.scan_policy or ScanPolicy()
+            if not policy.scan_user_secrets:
                 return []
         return super().scan(text, context)
 

--- a/sdk/tests/integration/test_client.py
+++ b/sdk/tests/integration/test_client.py
@@ -122,3 +122,15 @@ class TestUnplugClient:
             client = UnplugClient(base_url="http://localhost:8000")
             with pytest.raises(ServerError, match="malformed JSON"):
                 client.scan("hello")
+
+    def test_batch_missing_results_raises_server_error(self):
+        from unplug.exceptions import ServerError
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"error": "bad batch"}
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(httpx.Client, "post", return_value=mock_resp):
+            client = UnplugClient(base_url="http://localhost:8000")
+            with pytest.raises(ServerError, match="missing 'results'"):
+                client.batch_scan([ScanRequest(text="a")])


### PR DESCRIPTION
## Summary
- Fix Greptile follow-ups from merged PRs #27/#28: default `ScanPolicy` for USER secrets scan; `batch_scan` raises `ServerError` on missing `results`
- Add `unplug-scan-pr` CLI and composite action `.github/actions/unplug-scan` for PR agent-file scanning
- Refactor `pr-scan.yml` to use composite action; add `reusable-agent-scan.yml` for `workflow_call`

## Test plan
- [x] `cd sdk && make check-ci`
- [x] New test: batch response missing `results` → `ServerError`

## Greptile (addressed)
- PR #27 P1: leakage scanner when `context.scan_policy` is None
- PR #28 P1: `batch_scan` uncaught `KeyError`