### PR TITLE
Release unplug-ai 0.3.1

### DIFF
--- a/.github/actions/unplug-scan/README.md
+++ b/.github/actions/unplug-scan/README.md
@@ -23,7 +23,7 @@ jobs:
         with:
           base-ref: main
           install-mode: pypi
-          unplug-version: ">=0.3.0"
+          unplug-version: ">=0.3.1"
 ```
 
 ## Inputs
@@ -34,7 +34,7 @@ jobs:
 | `python-version` | `3.12` | Python version |
 | `working-directory` | `sdk` | Path to SDK tree when `install-mode: local` |
 | `install-mode` | `local` | `local` (uv sync) or `pypi` (install from PyPI) |
-| `unplug-version` | `>=0.3.0` | Version constraint for PyPI install |
+| `unplug-version` | `>=0.3.1` | Version constraint for PyPI install |
 
 ## What gets scanned
 

--- a/.github/actions/unplug-scan/action.yml
+++ b/.github/actions/unplug-scan/action.yml
@@ -21,7 +21,7 @@ inputs:
   unplug-version:
     description: PyPI version constraint when install-mode is pypi
     required: false
-    default: ">=0.3.0"
+    default: ">=0.3.1"
 
 runs:
   using: composite
@@ -56,5 +56,5 @@ runs:
           cd "${{ inputs.working-directory }}"
           uv run unplug-scan-pr --base-ref "${{ inputs.base-ref }}" --repo-root "$(git rev-parse --show-toplevel)"
         else
-          unplug-scan-pr --base-ref "${{ inputs.base-ref }}" --repo-root "$(git rev-parse --show-toplevel)"
+          python -m unplug.cli.scan_pr --base-ref "${{ inputs.base-ref }}" --repo-root "$(git rev-parse --show-toplevel)"
         fi

--- a/.github/workflows/reusable-agent-scan.yml
+++ b/.github/workflows/reusable-agent-scan.yml
@@ -17,7 +17,7 @@ on:
         description: PyPI version when install-mode is pypi
         required: false
         type: string
-        default: ">=0.3.0"
+        default: ">=0.3.1"
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the `unplug-ai` SDK.
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-06-13
+
+### Added
+
+- `unplug-scan-pr` CLI — scan changed agent/MCP config files in PRs (regex-only Guard)
+- GitHub composite action `.github/actions/unplug-scan` and reusable `workflow_call` workflow
+- `strict_scanner_allowlist` config — raise `ConfigError` when mandatory input scanners are omitted
+- Model cache revision + `config.json` digest verification in `ModelStore`
+- Judge sanitization — strip scanner finding evidence before BYOLLM prompts
+
+### Fixed
+
+- `ScanPolicy()` default when `context.scan_policy` is None — USER secret scanning no longer silently disabled
+- `ConfigError` from strict allowlist propagates from `Guard.scan_request` (not swallowed by fail-closed)
+- `UnplugClient.batch_scan` raises `ServerError` on missing or invalid `results` key
+- URL scanner evasion normalize with homoglyph/punycode patterns on raw text
+
+### Changed
+
+- Patch release bundling audit remediation (#27–#29) and Phase B distribution work (#30)
+
+## [0.3.0] — 2026-06-01
+
 ### Changed
 
 - **ABSTAIN semantics:** `ScanResult.safe` is `False` for `Action.ABSTAIN` by default; set `policy.abstain_is_safe = true` for legacy pass-through
@@ -44,8 +67,5 @@ All notable changes to the `unplug-ai` SDK.
 - `sdk/docs/ARCHITECTURE.md`, `RESTRUCTURE_PLAN.md`, `LOGIC_AUDIT.md`
 - Runtime dependency: `pyyaml`
 - `tests/unit/core/test_pattern_loader.py`
-
-## [0.3.0] — 2026-06-01
-
 - Dev branch workflow; PyPI publish from `main`
 - Safeguard registry, ML span model preview, agent hardening suite

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ make check-ci    # lint + tests + exfil demo + security regression
 ## Related repos
 
 - [unplug-mcp](https://github.com/UnplugAI/unplug-mcp): MCP server for Claude Code / Cursor
+- [unplug-scan-action](https://github.com/UnplugAI/unplug-scan-action): GitHub Action / Marketplace — PR agent-file scan
 - [unplug-server](https://github.com/UnplugAI/unplug-server): self-hosted API (premium tiers, later)
 
 ## License

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -155,6 +155,7 @@ Verify your wiring anytime:
 unplug-audit                   # wiring + ML status
 unplug-audit --probes          # FP + encoding + boundary batteries
 unplug-audit --require-ml      # fail if checkpoint / config / ML not active
+unplug-scan-pr --base-ref main # scan changed agent/MCP files in a PR (CI)
 ```
 
 | Check | Meaning |

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unplug-ai"
-version = "0.3.0"
+version = "0.3.1"
 description = "Unplug the bad AI. Fast prompt injection detection and redaction for LLM apps, agents, and RAG pipelines."
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/unplug/__init__.py
+++ b/sdk/src/unplug/__init__.py
@@ -73,7 +73,7 @@ try:
     # Single source of truth is pyproject.toml; avoids version drift.
     __version__ = _pkg_version("unplug-ai")
 except PackageNotFoundError:  # not installed (e.g. running from a source checkout)
-    __version__ = "0.3.0"
+    __version__ = "0.3.1"
 
 
 def __getattr__(name: str) -> object:

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -3332,7 +3332,7 @@ wheels = [
 
 [[package]]
 name = "unplug-ai"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Bump `unplug-ai` to **0.3.1** (patch: audit fixes, `unplug-scan-pr` CLI, distribution)
- Update CHANGELOG and lockfile
- Default composite action / reusable workflow to `>=0.3.1`

## After merge
- Merge `dev` → `main`, tag `v0.3.1`, GitHub Release → PyPI publish