### PR TITLE
Surface regex vs ML benchmarks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Try it without installing anything: [live demo](https://huggingface.co/spaces/Un
 | ML span model `Guard.with_tiny()` | **Preview** ([unplug-tiny-v1](https://huggingface.co/Unplug-AI/unplug-tiny-v1)) |
 | Sliding-window long documents + streaming scan | **Included** |
 
-Regex-only doc-level detection reaches roughly **F1 0.36 / recall 0.23** on held-out attacks: fine as a first line, not sufficient alone. The ML span model's measured per-axis numbers (including failures) are on the [model card](https://huggingface.co/Unplug-AI/unplug-tiny-v1).
+On the neuralchemy prompt-injection set, regex-only detection reaches **F1 0.56 / recall 0.39** — a fast first line, not sufficient alone. Adding the ML span model (`Guard.with_tiny()`) takes that to **F1 0.99 / recall 0.98**, and lifts recall on *indirect* injection from **0.05 → 0.91**. False-positive rate stays under 1% on the injection set (2.1% on a separate hard-benign corpus). Full tables, methodology, and honest caveats: [`sdk/docs/BENCHMARKS.md`](sdk/docs/BENCHMARKS.md). Per-axis model metrics (including failure modes) are on the [model card](https://huggingface.co/Unplug-AI/unplug-tiny-v1).
 
 ## Agent host checklist
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -84,7 +84,14 @@ Reproduce (downloads `unplug-tiny-v1` from Hugging Face on first ML run):
 ```bash
 cd sdk && uv sync --all-extras --dev
 uv run python -m benchmarks.download --dataset all --out benchmarks/data
+
+# regex-only baseline (table rows 1 and 3)
+uv run python -m benchmarks.run benchmarks/data/neuralchemy.jsonl --isolated --format json
+uv run python -m benchmarks.run benchmarks/data/microsoft_indirect.jsonl --isolated --format json
+
+# regex + ML (rows 2 and 4; downloads unplug-tiny-v1 on first run)
 uv run python -m benchmarks.run benchmarks/data/neuralchemy.jsonl --ml --isolated --format json
+uv run python -m benchmarks.run benchmarks/data/microsoft_indirect.jsonl --ml --isolated --format json
 ```
 
 Full methodology, per-dataset tables, and honest caveats: [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -60,6 +60,36 @@ result = guard.scan(rag_chunk, source="retrieved")
 
 No install needed to try it: [live demo on Hugging Face](https://huggingface.co/spaces/Unplug-AI/unplug-tiny-demo).
 
+## Benchmarks
+
+Regex alone is a fast first line; the ML span model is what catches what regex
+structurally cannot — especially **indirect** injection hidden in retrieved
+content. The headline, measured on public injection datasets in isolated
+single-turn sessions:
+
+| Dataset | Mode | Recall | F1 | FPR |
+| --- | --- | ---: | ---: | ---: |
+| neuralchemy (direct, 4,391) | regex-only | 0.39 | 0.56 | <1% |
+| neuralchemy (direct, 4,391) | **regex + ML** | **0.98** | **0.99** | <1% |
+| microsoft llmail (indirect, 2,500) | regex-only | 0.05 | — | — |
+| microsoft llmail (indirect, 2,500) | **regex + ML** | **0.91** | — | — |
+
+Precision stays ~0.99 in both modes. The `<1%` FPR is on the injection set; on a
+separate hard-benign corpus (95 prompts) regex flags 0 and regex + ML flags 2,
+i.e. **2.1%** (one of which is a *review*, not a block). `inj_threshold` is tuned
+to the recall/FPR knee.
+
+Reproduce (downloads `unplug-tiny-v1` from Hugging Face on first ML run):
+
+```bash
+cd sdk && uv sync --all-extras --dev
+uv run python -m benchmarks.download --dataset all --out benchmarks/data
+uv run python -m benchmarks.run benchmarks/data/neuralchemy.jsonl --ml --isolated --format json
+```
+
+Full methodology, per-dataset tables, and honest caveats: [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md).
+Per-axis model metrics (including failure modes) live on the [model card](https://huggingface.co/Unplug-AI/unplug-tiny-v1).
+
 ## Protect an agent
 
 Wire Unplug into any agent that fetches external content or calls tools:
@@ -204,7 +234,7 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for layering and optional extra
 | Doc | Covers |
 |-----|--------|
 | [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) | Hosted vs embedded vs sidecar architecture |
-| [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) | Regex SDK eval results (neuralchemy, microsoft) |
+| [`docs/BENCHMARKS.md`](docs/BENCHMARKS.md) | Regex vs regex + ML eval results (neuralchemy, microsoft) |
 | [`docs/ML_INTEGRATION.md`](docs/ML_INTEGRATION.md) | Checkpoint layout, thresholds, long-text and streaming config |
 | [`docs/INTEGRATIONS.md`](docs/INTEGRATIONS.md) | LangGraph, Agno, framework-agnostic hooks |
 | [`docs/AGENT_FLOW_SECURITY.md`](docs/AGENT_FLOW_SECURITY.md) | End-to-end agent hardening flow |


### PR DESCRIPTION
Puts the measured regex vs regex + ML detection numbers where users actually look — the SDK README and the top-level README — instead of only in `docs/BENCHMARKS.md`.

## What changed
- **sdk/README.md**: new `## Benchmarks` section after the quickstart — headline table (direct recall 0.39 → 0.98, F1 0.56 → 0.99; indirect recall 0.05 → 0.91), repro command, link to full methodology.
- **README.md**: replaced the orphan "F1 0.36 / recall 0.23 on held-out attacks" line with the same neuralchemy/microsoft numbers, so every surface tells one consistent story.

## Honesty
- FPR is reported as `<1%` on the injection set and **2.1%** (2/95) on a separate hard-benign corpus — both stated, neither hidden.
- Single-turn methodology and the attacks-only microsoft subset are called out; precision (~0.99 both modes) included.
- All numbers trace to `sdk/docs/BENCHMARKS.md` (the source of truth).

Stacks on #34 (the ML recall gate that produces these numbers).