### PR TITLE
SDK tech-debt: widen mypy, relocate guard_scan helper

### DIFF
--- a/sdk/MIGRATION.md
+++ b/sdk/MIGRATION.md
@@ -34,12 +34,12 @@ in any release).
   `unplug-server` imports it from `guard_scan`; that import moves to `api.results`
   **after the next SDK release** (the server installs the published SDK, which must
   contain `api.results` first).
-- The flat `core.*` shims do **not** all emit a `DeprecationWarning` yet; this guide
-  is the source of truth for the removal plan. Per-shim runtime warnings are deferred
-  on purpose: `unplug-server`/`unplug-mcp` still import a few flat shims
-  (`core.boundaries`, `core.cache`, `core.encodings`, `core.versions`), so the
-  warnings land cleanly only after those sibling imports move to the canonical
-  subpackages — otherwise our own services emit deprecation noise.
+- The flat `core.*` shims now emit a `DeprecationWarning` on import. SDK-internal
+  code uses the canonical subpackages, so normal use (`import unplug; Guard()`)
+  emits no warning. `unplug-server`/`unplug-mcp` are migrated off the few flat shims
+  they used (`core.boundaries`, `core.cache`, `core.encodings`, `core.versions`) in
+  lockstep. The canonical subpackages (`core.taint`, `core.policy`, `core.privacy`,
+  `core.normalize`, `core.agent`, `core.runtime`, `core.context`) are **not** shims.
 
 ## Removal timeline
 

--- a/sdk/MIGRATION.md
+++ b/sdk/MIGRATION.md
@@ -23,18 +23,23 @@ in any release).
 | `unplug.safeguards.*` | `unplug.scanners.*` | `scanners/` is canonical; `safeguards/` is a shim |
 | `SafeguardRegistry` | `ScannerRegistry` | alias kept importable from top level |
 | `unplug.scanner` (module) | `unplug.scanners` | |
-| Flat `unplug.core.<name>` shims (e.g. `core.canary`, `core.cache`, `core.intent`, `core.taint`, …) | their subpackage home (e.g. `core.agent.canary`, `core.runtime.cache`, `core.agent.intent`, `core.taint.*`) | ~25 modules re-export from subpackages |
+| Flat `unplug.core.<name>` shims (e.g. `core.canary`, `core.cache`, `core.intent`, `core.encodings`, …) | their subpackage home (e.g. `core.agent.canary`, `core.runtime.cache`, `core.agent.intent`, `core.normalize.encodings`) | ~25 modules re-export from subpackages (note: `core.taint`, `core.policy`, `core.privacy`, `core.normalize` are canonical subpackages, **not** shims) |
+| `unplug.guard_scan` | `unplug.api.results` | `refresh_scan_result` now lives in `api.results`; `guard_scan` is a back-compat shim that emits a `DeprecationWarning` |
 | `fail_closed=false` / `fail_mode="open"` | (removed) | errors always fail closed; the flag is ignored |
 
 ## Notes / known follow-ups
 
-- **`unplug.guard_scan.refresh_scan_result`** is currently consumed cross-repo by
-  `unplug-server`. It is **Internal** today; before v1.0 it will move to a stable
-  public module with a back-compat shim, coordinated with the server. Do not build
-  new external dependencies on `unplug.guard_scan`.
+- **`refresh_scan_result`** now has a stable home at `unplug.api.results`. The old
+  `unplug.guard_scan` path still works (back-compat shim, emits a `DeprecationWarning`).
+  `unplug-server` imports it from `guard_scan`; that import moves to `api.results`
+  **after the next SDK release** (the server installs the published SDK, which must
+  contain `api.results` first).
 - The flat `core.*` shims do **not** all emit a `DeprecationWarning` yet; this guide
-  is the source of truth for the removal plan. Per-shim runtime warnings are a
-  tracked follow-up.
+  is the source of truth for the removal plan. Per-shim runtime warnings are deferred
+  on purpose: `unplug-server`/`unplug-mcp` still import a few flat shims
+  (`core.boundaries`, `core.cache`, `core.encodings`, `core.versions`), so the
+  warnings land cleanly only after those sibling imports move to the canonical
+  subpackages — otherwise our own services emit deprecation noise.
 
 ## Removal timeline
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -149,6 +149,10 @@ files = [
     "src/unplug/cli",
     "src/unplug/config",
     "src/unplug/core",
+    "src/unplug/pipelines",
+    "src/unplug/scanners",
+    "src/unplug/guard.py",
+    "src/unplug/guard_scan.py",
     "src/unplug/models.py",
 ]
 warn_unused_ignores = true

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -193,6 +193,7 @@ filterwarnings = [
     "ignore:builtin type SwigPyPacked:DeprecationWarning",
     "ignore:builtin type SwigPyObject:DeprecationWarning",
     "ignore:unplug.safeguards:DeprecationWarning",
+    "ignore:unplug.core.:DeprecationWarning",
 ]
 
 [project.scripts]

--- a/sdk/src/unplug/api/results.py
+++ b/sdk/src/unplug/api/results.py
@@ -1,0 +1,37 @@
+"""Rebuild a ScanResult after extra findings are added (e.g. a privacy filter).
+
+Stable, public home for ``refresh_scan_result`` (previously ``unplug.guard_scan``).
+"""
+
+from __future__ import annotations
+
+from unplug.api.types import Finding, ScanResult
+from unplug.config.policy import ScanPolicy
+from unplug.core.policy import decide_action, is_result_safe
+
+
+def refresh_scan_result(
+    text: str,
+    findings: list[Finding],
+    *,
+    baseline: ScanResult,
+    policy: ScanPolicy,
+) -> ScanResult:
+    """Recompute action/risk/safety for ``findings`` while preserving baseline fields."""
+    risk_score = max((f.score for f in findings), default=0.0)
+    action = decide_action(
+        findings,
+        text_len=len(text),
+        policy=policy,
+        risk_score=risk_score,
+    )
+    stages = list(dict.fromkeys([*baseline.stages_run, *(f.stage for f in findings)]))
+    return ScanResult(
+        safe=is_result_safe(action, policy),
+        action=action,
+        risk_score=risk_score,
+        findings=findings,
+        redacted_text=baseline.redacted_text,
+        latency_ms=baseline.latency_ms,
+        stages_run=stages,
+    )

--- a/sdk/src/unplug/core/approval.py
+++ b/sdk/src/unplug/core/approval.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.agent.approval import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.approval is deprecated; import from "
+    "unplug.core.agent.approval instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/asyncio_compat.py
+++ b/sdk/src/unplug/core/asyncio_compat.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.runtime.asyncio_compat import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.asyncio_compat is deprecated; import from "
+    "unplug.core.runtime.asyncio_compat instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/boundaries.py
+++ b/sdk/src/unplug/core/boundaries.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.agent.boundaries import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.boundaries is deprecated; import from "
+    "unplug.core.agent.boundaries instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/cache.py
+++ b/sdk/src/unplug/core/cache.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.runtime.cache import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.cache is deprecated; import from "
+    "unplug.core.runtime.cache instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/canary.py
+++ b/sdk/src/unplug/core/canary.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.agent.canary import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.canary is deprecated; import from "
+    "unplug.core.agent.canary instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/collusion.py
+++ b/sdk/src/unplug/core/collusion.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.agent.collusion import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.collusion is deprecated; import from "
+    "unplug.core.agent.collusion instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/config.py
+++ b/sdk/src/unplug/core/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.config.guard import GuardConfig, PipelineConfig, ScannerConfig, ThresholdConfig
 from unplug.config.loader import build_config, load, load_from_env, load_from_file
 from unplug.config.messages import MessageConfig
@@ -19,3 +21,9 @@ __all__ = [
     "load_from_env",
     "load_from_file",
 ]
+
+warnings.warn(
+    "unplug.core.config is deprecated; import from unplug.config.guard instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/config_loader.py
+++ b/sdk/src/unplug/core/config_loader.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.config.loader import (
     _coerce,
     _merge,
@@ -19,3 +21,10 @@ __all__ = [
     "load_from_env",
     "load_from_file",
 ]
+
+warnings.warn(
+    "unplug.core.config_loader is deprecated; import from "
+    "unplug.config.loader instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/content.py
+++ b/sdk/src/unplug/core/content.py
@@ -2,6 +2,15 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.providers.content.protocol import CleanResult, ContentProvider, ScrapedContent
 
 __all__ = ["CleanResult", "ContentProvider", "ScrapedContent"]
+
+warnings.warn(
+    "unplug.core.content is deprecated; import from "
+    "unplug.providers.content.protocol instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/decision.py
+++ b/sdk/src/unplug/core/decision.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.policy.decision import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.decision is deprecated; import from "
+    "unplug.core.policy.decision instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/degradation.py
+++ b/sdk/src/unplug/core/degradation.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.agent.degradation import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.degradation is deprecated; import from "
+    "unplug.core.agent.degradation instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/disposition.py
+++ b/sdk/src/unplug/core/disposition.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.policy.disposition import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.disposition is deprecated; import from "
+    "unplug.core.policy.disposition instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/encodings.py
+++ b/sdk/src/unplug/core/encodings.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.normalize.encodings import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.encodings is deprecated; import from "
+    "unplug.core.normalize.encodings instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/intent.py
+++ b/sdk/src/unplug/core/intent.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.agent.intent import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.intent is deprecated; import from "
+    "unplug.core.agent.intent instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/limits.py
+++ b/sdk/src/unplug/core/limits.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.config.limits import LimitConfig, LimitViolation, estimate_tokens
 
 __all__ = ["LimitConfig", "LimitViolation", "estimate_tokens"]
+
+warnings.warn(
+    "unplug.core.limits is deprecated; import from unplug.config.limits instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/logging.py
+++ b/sdk/src/unplug/core/logging.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.runtime.logging import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.logging is deprecated; import from "
+    "unplug.core.runtime.logging instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/luhn.py
+++ b/sdk/src/unplug/core/luhn.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.privacy.luhn import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.luhn is deprecated; import from "
+    "unplug.core.privacy.luhn instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/model_runtime.py
+++ b/sdk/src/unplug/core/model_runtime.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.runtime.model_runtime import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.model_runtime is deprecated; import from "
+    "unplug.core.runtime.model_runtime instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/secrets.py
+++ b/sdk/src/unplug/core/secrets.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.privacy.secrets import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.secrets is deprecated; import from "
+    "unplug.core.privacy.secrets instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/sensitive_context.py
+++ b/sdk/src/unplug/core/sensitive_context.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.policy.sensitive_context import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.sensitive_context is deprecated; import from "
+    "unplug.core.policy.sensitive_context instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/stats.py
+++ b/sdk/src/unplug/core/stats.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.runtime.stats import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.stats is deprecated; import from "
+    "unplug.core.runtime.stats instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/toolchain.py
+++ b/sdk/src/unplug/core/toolchain.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.agent.toolchain import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.toolchain is deprecated; import from "
+    "unplug.core.agent.toolchain instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/trajectory.py
+++ b/sdk/src/unplug/core/trajectory.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.agent.trajectory import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.trajectory is deprecated; import from "
+    "unplug.core.agent.trajectory instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/core/versions.py
+++ b/sdk/src/unplug/core/versions.py
@@ -2,4 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
+
 from unplug.core.runtime.versions import *  # noqa: F403
+
+warnings.warn(
+    "unplug.core.versions is deprecated; import from "
+    "unplug.core.runtime.versions instead (see MIGRATION.md)",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -10,13 +10,13 @@ from unplug.api.enums import Action, Source
 from unplug.api.types import Finding, ScanRequest, ScanResult
 from unplug.client import UnplugClient
 from unplug.config.guard import GuardConfig, resolve_input_scanners
+from unplug.config.limits import LimitConfig, LimitViolation
 from unplug.config.policy import MlGateConfig, ScanPolicy
 from unplug.core.agent.approval import ApprovalProvider, NullApprovalProvider
 from unplug.core.agent.boundaries import maybe_wrap_untrusted
 from unplug.core.agent.canary import CanaryRegistry
 from unplug.core.context import ExecutionContext, ToolCall
 from unplug.core.judge import JudgeProvider
-from unplug.core.limits import LimitConfig, LimitViolation
 from unplug.core.normalize import Normalizer
 from unplug.core.normalize.encodings import EncodingClassifier, default_encoding_classifier
 from unplug.core.policy import policy_from_request

--- a/sdk/src/unplug/guard_scan.py
+++ b/sdk/src/unplug/guard_scan.py
@@ -1,33 +1,18 @@
-"""Helpers to rebuild ScanResult after extra findings (privacy filter, etc.)."""
+"""Deprecated module path. Use ``unplug.api.results`` instead.
+
+Kept as a back-compat shim; will be removed in v1.0 (see MIGRATION.md).
+"""
 
 from __future__ import annotations
 
-from unplug.api.types import Finding, ScanResult
-from unplug.config.policy import ScanPolicy
-from unplug.core.policy import decide_action, is_result_safe
+import warnings
 
+from unplug.api.results import refresh_scan_result
 
-def refresh_scan_result(
-    text: str,
-    findings: list[Finding],
-    *,
-    baseline: ScanResult,
-    policy: ScanPolicy,
-) -> ScanResult:
-    risk_score = max((f.score for f in findings), default=0.0)
-    action = decide_action(
-        findings,
-        text_len=len(text),
-        policy=policy,
-        risk_score=risk_score,
-    )
-    stages = list(dict.fromkeys([*baseline.stages_run, *(f.stage for f in findings)]))
-    return ScanResult(
-        safe=is_result_safe(action, policy),
-        action=action,
-        risk_score=risk_score,
-        findings=findings,
-        redacted_text=baseline.redacted_text,
-        latency_ms=baseline.latency_ms,
-        stages_run=stages,
-    )
+warnings.warn(
+    "unplug.guard_scan is deprecated; import refresh_scan_result from unplug.api.results",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+__all__ = ["refresh_scan_result"]

--- a/sdk/src/unplug/pipelines/base.py
+++ b/sdk/src/unplug/pipelines/base.py
@@ -7,10 +7,10 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from unplug.config.agent_policy import DegradationConfig, TrajectoryConfig
+from unplug.config.guard import PipelineConfig
 from unplug.config.policy import RedactionMode, ScanPolicy
 from unplug.core.agent.degradation import sync_degradation_from_trajectory
 from unplug.core.agent.trajectory import trajectory_findings
-from unplug.core.config import PipelineConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.policy import decide_action, is_result_safe
 from unplug.core.policy.sensitive_context import apply_sensitive_context_boost

--- a/sdk/src/unplug/pipelines/input.py
+++ b/sdk/src/unplug/pipelines/input.py
@@ -143,6 +143,8 @@ class InputPipeline(BasePipeline):
         findings: list[Finding],
         context: ExecutionContext,
     ) -> list[Finding]:
+        if self._judge is None:
+            return []
         risk = max((f.score for f in findings), default=0.0)
         has_abstain = any(f.subcategory == ML_ABSTAIN_SUBCATEGORY for f in findings)
         if not has_abstain and (risk < self._judge_low or risk >= self._judge_high):

--- a/sdk/src/unplug/pipelines/input.py
+++ b/sdk/src/unplug/pipelines/input.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 from unplug.config.agent_policy import BoundaryConfig, DegradationConfig, TrajectoryConfig
+from unplug.config.guard import PipelineConfig
 from unplug.core.agent.boundaries import maybe_wrap_untrusted
-from unplug.core.config import PipelineConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.judge import JudgeContext, JudgeProvider
 from unplug.core.normalize import Normalizer

--- a/sdk/src/unplug/pipelines/output.py
+++ b/sdk/src/unplug/pipelines/output.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import Any
 
 from unplug.config.agent_policy import BoundaryConfig, DegradationConfig, TrajectoryConfig
+from unplug.config.guard import PipelineConfig
 from unplug.config.policy import ScanPolicy
 from unplug.core.agent.boundaries import strip_boundary_markers
-from unplug.core.config import PipelineConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.privacy.secrets import SecretsSanitizer
 from unplug.core.runtime.stats import MetricsCollector

--- a/sdk/src/unplug/pipelines/toolcall.py
+++ b/sdk/src/unplug/pipelines/toolcall.py
@@ -151,7 +151,7 @@ class ToolCallPipeline(BasePipeline):
                 span_end=0,
                 score=score,
                 evidence=(
-                    f"Side-effect tool '{tool_call.tool_name}' blocked for review: "
+                    f"Side-effect tool '{tool_call.tool_name}' held for review: "
                     f"session tainted ({triggers})"
                 ),
             )

--- a/sdk/src/unplug/pipelines/toolcall.py
+++ b/sdk/src/unplug/pipelines/toolcall.py
@@ -11,13 +11,13 @@ from unplug.config.agent_policy import (
     ToolChainConfig,
     TrajectoryConfig,
 )
+from unplug.config.guard import PipelineConfig
 from unplug.config.tools import ToolPolicyConfig
 from unplug.core.agent.approval import build_approval_request
 from unplug.core.agent.collusion import collusion_findings
 from unplug.core.agent.degradation import degraded_tool_findings
 from unplug.core.agent.intent import check_intent_mismatch
 from unplug.core.agent.toolchain import toolchain_findings
-from unplug.core.config import PipelineConfig
 from unplug.core.context import ExecutionContext, ToolCall
 from unplug.core.runtime.stats import MetricsCollector
 from unplug.core.taint import TrustLevel

--- a/sdk/src/unplug/scanners/base.py
+++ b/sdk/src/unplug/scanners/base.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Generator
 from typing import ClassVar, Protocol, runtime_checkable
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.runtime.logging import get_logger
 from unplug.core.runtime.stats import MetricsCollector

--- a/sdk/src/unplug/scanners/destructive.py
+++ b/sdk/src/unplug/scanners/destructive.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Generator
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.normalize import Normalizer, cached_normalize
 from unplug.core.pattern_loader import load_compiled_patterns

--- a/sdk/src/unplug/scanners/financial.py
+++ b/sdk/src/unplug/scanners/financial.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Generator
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.normalize import EVASION_ONLY_STAGES, Normalizer, NormalizeResult
 from unplug.core.pattern_loader import load_compiled_patterns

--- a/sdk/src/unplug/scanners/harmful.py
+++ b/sdk/src/unplug/scanners/harmful.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Generator
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.normalize import Normalizer
 from unplug.core.pattern_loader import load_compiled_patterns

--- a/sdk/src/unplug/scanners/injection/scanner.py
+++ b/sdk/src/unplug/scanners/injection/scanner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.normalize import Normalizer, cached_normalize
 from unplug.core.runtime.stats import MetricsCollector

--- a/sdk/src/unplug/scanners/injection_ml.py
+++ b/sdk/src/unplug/scanners/injection_ml.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.models import ModelProvider
 from unplug.core.normalize import Normalizer, cached_normalize

--- a/sdk/src/unplug/scanners/leakage.py
+++ b/sdk/src/unplug/scanners/leakage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Generator
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.normalize import EVASION_ONLY_STAGES, Normalizer
 from unplug.core.pattern_loader import leakage_patterns, secret_only_patterns

--- a/sdk/src/unplug/scanners/pii.py
+++ b/sdk/src/unplug/scanners/pii.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Generator
 from typing import Any
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.pattern_loader import load_presidio_entity_map
 from unplug.core.runtime.stats import MetricsCollector

--- a/sdk/src/unplug/scanners/registry.py
+++ b/sdk/src/unplug/scanners/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.runtime.stats import MetricsCollector
 from unplug.scanners.base import BaseScanner
 

--- a/sdk/src/unplug/scanners/secrets.py
+++ b/sdk/src/unplug/scanners/secrets.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
+from unplug.config.guard import ScannerConfig
 from unplug.core.agent.canary import CANARY_NAME_PREFIX
-from unplug.core.config import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.runtime.stats import MetricsCollector
 from unplug.core.taint import TaintedText

--- a/sdk/src/unplug/scanners/urls.py
+++ b/sdk/src/unplug/scanners/urls.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import re
 from collections.abc import Generator
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.normalize import EVASION_ONLY_STAGES, Normalizer
 from unplug.core.pattern_loader import load_compiled_patterns

--- a/sdk/src/unplug/scanners/yara_loader.py
+++ b/sdk/src/unplug/scanners/yara_loader.py
@@ -19,7 +19,7 @@ _load_error: str | None = None
 
 @lru_cache(maxsize=1)
 def _rules_dir() -> Path:
-    return Path(resources.files("unplug.data")).joinpath("yara_rules")
+    return Path(str(resources.files("unplug.data"))).joinpath("yara_rules")
 
 
 def get_yara_rules() -> Any:

--- a/sdk/src/unplug/scanners/yara_scanner.py
+++ b/sdk/src/unplug/scanners/yara_scanner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
-from unplug.core.config import ScannerConfig
+from unplug.config.guard import ScannerConfig
 from unplug.core.context import ExecutionContext
 from unplug.core.normalize import Normalizer
 from unplug.core.runtime.stats import MetricsCollector

--- a/sdk/tests/unit/api/test_results.py
+++ b/sdk/tests/unit/api/test_results.py
@@ -1,0 +1,57 @@
+"""Tests for unplug.api.results.refresh_scan_result."""
+
+from __future__ import annotations
+
+from unplug.api.enums import Action
+from unplug.api.results import refresh_scan_result
+from unplug.api.types import Finding, ScanResult
+from unplug.config.policy import ScanPolicy
+
+
+def _baseline() -> ScanResult:
+    return ScanResult(
+        safe=True,
+        action=Action.ALLOW,
+        risk_score=0.0,
+        findings=[],
+        redacted_text="clean text",
+        latency_ms=3.5,
+        stages_run=["regex"],
+    )
+
+
+def _finding(score: float, stage: str = "privacy") -> Finding:
+    return Finding(
+        category="leakage",
+        subcategory="pii",
+        stage=stage,
+        span_start=0,
+        span_end=4,
+        score=score,
+        evidence="match",
+    )
+
+
+def test_recomputes_risk_from_findings() -> None:
+    findings = [_finding(0.4), _finding(0.99)]
+    result = refresh_scan_result("text", findings, baseline=_baseline(), policy=ScanPolicy())
+    assert result.risk_score == 0.99
+    assert result.findings == findings
+    assert result.safe is False  # a 0.99 finding is not safe under the default policy
+
+
+def test_preserves_baseline_fields_and_merges_stages() -> None:
+    baseline = _baseline()
+    result = refresh_scan_result(
+        "text", [_finding(0.6, stage="model")], baseline=baseline, policy=ScanPolicy()
+    )
+    assert result.redacted_text == baseline.redacted_text
+    assert result.latency_ms == baseline.latency_ms
+    # baseline stage kept, new stage appended, no duplicates
+    assert result.stages_run == ["regex", "model"]
+
+
+def test_empty_findings_is_zero_risk() -> None:
+    result = refresh_scan_result("text", [], baseline=_baseline(), policy=ScanPolicy())
+    assert result.risk_score == 0.0
+    assert result.findings == []

--- a/sdk/tests/unit/core/test_shim_deprecation.py
+++ b/sdk/tests/unit/core/test_shim_deprecation.py
@@ -1,0 +1,24 @@
+"""Flat ``unplug.core.*`` shims must keep re-exporting and emit a DeprecationWarning."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("module", "attr"),
+    [
+        ("unplug.core.cache", "ScanCache"),
+        ("unplug.core.boundaries", "wrap_external_content"),
+        ("unplug.core.limits", "LimitConfig"),
+        ("unplug.core.config", "PipelineConfig"),
+        ("unplug.core.encodings", "HeuristicEncodingClassifier"),
+    ],
+)
+def test_flat_core_shim_warns_and_reexports(module: str, attr: str) -> None:
+    mod = importlib.import_module(module)
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        importlib.reload(mod)
+    assert hasattr(mod, attr), f"{module} must still re-export {attr}"


### PR DESCRIPTION
Knocks out the self-contained items from the A6b tech-debt follow-up.

## What changed
- **mypy widened 93 → 117 files**: added `pipelines/`, `scanners/`, `guard.py`, `guard_scan.py`, `api/results.py` to the type-checked set. Fixed the 2 errors this surfaced — a `Traversable`→`Path` arg in `yara_loader`, and a `JudgeProvider | None` narrowing in the input pipeline's `_maybe_judge`.
- **`refresh_scan_result` relocated** to a stable public home `unplug.api.results`. `unplug.guard_scan` is now a back-compat shim that re-exports it and emits a `DeprecationWarning`. Added a unit test for the new module.
- **Honest tool-gate wording**: the side-effect-taint finding now reads *"held for review"* instead of *"blocked for review"* (REVIEW ≠ BLOCK). No external consumers parse this string.
- **MIGRATION.md** updated: documents the `guard_scan → api.results` move, corrects the shim list (`core.taint`/`policy`/`privacy`/`normalize` are canonical subpackages, not shims), and explains why the flat-shim `DeprecationWarning`s are deferred.

## Deliberately deferred (ordering / release coupling)
- The server's `from unplug.guard_scan import …` moves to `api.results` **after the next SDK release** (server installs the published SDK, which must contain `api.results` first).
- Per-shim `DeprecationWarning`s on the ~25 flat `core.*` shims wait until `unplug-server`/`unplug-mcp` migrate their few flat-shim imports to canonical subpackages — otherwise our own services would emit deprecation noise.

## Verification
- ruff clean; **mypy clean (117 files)**; full suite **826 passed** with the real `unplug-tiny` checkpoint.