### PR TITLE
Expose degradation metadata and privacy filter support

### DIFF
--- a/sdk/src/unplug/api/types.py
+++ b/sdk/src/unplug/api/types.py
@@ -48,6 +48,14 @@ class ScanResult(BaseModel):
     redacted_text: str | None = Field(default=None)
     latency_ms: float = Field(description="Total scan time in milliseconds")
     stages_run: list[str] = Field(default_factory=list)
+    degraded: bool = Field(
+        default=False,
+        description="Whether one or more configured protection layers were unavailable",
+    )
+    degraded_layers: list[str] = Field(
+        default_factory=list,
+        description="Configured layers that were unavailable and degraded this result",
+    )
     approval: ApprovalRequest | None = Field(
         default=None,
         description="Populated when action=review for side-effect tools in tainted sessions",

--- a/sdk/src/unplug/cli/scan_pr.py
+++ b/sdk/src/unplug/cli/scan_pr.py
@@ -82,7 +82,7 @@ def main_argv(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Scan agent-related files changed in a PR with unplug-ai (regex-only)",
     )
-    parser.add_argument("--base-ref", default="dev", help="Base branch name (default: dev)")
+    parser.add_argument("--base-ref", default="main", help="Base branch name (default: main)")
     parser.add_argument(
         "--repo-root",
         type=Path,

--- a/sdk/src/unplug/core/pattern_loader.py
+++ b/sdk/src/unplug/core/pattern_loader.py
@@ -73,6 +73,21 @@ def load_privacy_label_map() -> dict[str, str]:
     return dict(labels.labels)
 
 
+@lru_cache(maxsize=1)
+def load_privacy_entity_label_map() -> dict[str, str]:
+    """Map NER entity labels from a token-classification privacy model."""
+    raw = _read_text("unplug.data.maps", "privacy_entity_labels.toml")
+    parsed = tomllib.loads(raw)
+    entities = parsed.get("entities", {})
+    result: dict[str, str] = {}
+    for name, spec in entities.items():
+        if isinstance(spec, dict):
+            result[str(name).upper()] = str(spec.get("subcategory", "private_other"))
+        else:
+            result[str(name).upper()] = str(spec)
+    return result
+
+
 def leakage_patterns() -> list[tuple[str, re.Pattern[str]]]:
     """Secrets + PII + prompt-leak patterns for the leakage scanner."""
     combined: list[tuple[str, re.Pattern[str]]] = []

--- a/sdk/src/unplug/core/privacy/__init__.py
+++ b/sdk/src/unplug/core/privacy/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from unplug.core.privacy.model_filter import TokenPrivacyFilter
 from unplug.core.privacy.privacy import (
     HeuristicPrivacyFilter,
     NullPrivacyFilter,
@@ -16,5 +17,6 @@ __all__ = [
     "PrivacyFilterService",
     "SecretsRegistry",
     "SecretsSanitizer",
+    "TokenPrivacyFilter",
     "build_privacy_filter",
 ]

--- a/sdk/src/unplug/core/privacy/model_filter.py
+++ b/sdk/src/unplug/core/privacy/model_filter.py
@@ -1,0 +1,156 @@
+"""Production privacy filter backed by a token-classification checkpoint."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from unplug.api.types import Finding
+from unplug.core.pattern_loader import load_privacy_entity_label_map, load_privacy_label_map
+from unplug.core.privacy.ner_decode import decode_ner_spans, normalize_ner_label
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedModel, PreTrainedTokenizerBase
+
+_logger = logging.getLogger("unplug.privacy.model")
+
+
+class TokenPrivacyFilter:
+    """NER/token-classification checkpoint for PII and secret span detection."""
+
+    def __init__(
+        self,
+        model_source: str | Path,
+        *,
+        threshold: float = 0.5,
+        max_length: int = 512,
+        device: str | None = None,
+        local_files_only: bool = False,
+        eager_load: bool = True,
+    ) -> None:
+        self._model_source = str(model_source)
+        self._threshold = threshold
+        self._max_length = max_length
+        self._local_files_only = local_files_only
+        self._entity_map = load_privacy_entity_label_map()
+        self._pf_label_map = load_privacy_label_map()
+        self._tokenizer: PreTrainedTokenizerBase | None = None
+        self._model: PreTrainedModel | None = None
+        self._device: str | None = device
+        if eager_load:
+            self.load()
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+    @property
+    def model_source(self) -> str:
+        return self._model_source
+
+    def load(self) -> None:
+        if self._model is not None:
+            return
+        try:
+            import torch
+            from transformers import AutoModelForTokenClassification, AutoTokenizer
+        except ImportError as exc:
+            msg = (
+                "TokenPrivacyFilter requires transformers and torch; "
+                "install unplug-ai[ml] or server [ml] extra"
+            )
+            raise RuntimeError(msg) from exc
+
+        from unplug.ml.device import resolve_torch_device
+
+        source = self._model_source
+        path = Path(source)
+        load_kwargs = {"local_files_only": self._local_files_only}
+        if path.is_dir():
+            source = str(path)
+
+        self._tokenizer = AutoTokenizer.from_pretrained(source, **load_kwargs)
+        self._model = AutoModelForTokenClassification.from_pretrained(
+            source,
+            **load_kwargs,
+            use_safetensors=True,
+            torch_dtype=torch.float32,
+        )
+        device = resolve_torch_device(self._device)
+        self._model.to(device)
+        self._model.eval()
+        self._device = device
+        _logger.info("Loaded token privacy filter from %s on %s", self._model_source, device)
+
+    def unload(self) -> None:
+        self._model = None
+        self._tokenizer = None
+
+    def _entity_to_subcategory(self, entity: str) -> str:
+        key = entity.strip().upper()
+        return self._entity_map.get(key, self._entity_map.get("DEFAULT", "private_other"))
+
+    def scan(self, text: str, *, baseline: list[Finding]) -> list[Finding]:
+        if not text:
+            return baseline
+        self.load()
+        tokenizer = self._tokenizer
+        model = self._model
+        if tokenizer is None or model is None:
+            msg = "Privacy filter failed to load tokenizer/model"
+            raise RuntimeError(msg)
+
+        import torch
+
+        covered = {(f.span_start, f.span_end) for f in baseline}
+        extra: list[Finding] = []
+
+        encoding = self._tokenizer(
+            text,
+            return_offsets_mapping=True,
+            truncation=True,
+            max_length=self._max_length,
+            return_tensors="pt",
+        )
+        offsets = encoding.pop("offset_mapping")[0].tolist()
+        model_inputs = {k: v.to(self._device) for k, v in encoding.items()}
+
+        with torch.no_grad():
+            logits = model(**model_inputs).logits[0]
+
+        probs = torch.softmax(logits, dim=-1)
+        id2label = {int(k): str(v) for k, v in model.config.id2label.items()}
+        labels: list[str] = []
+        scores: list[float] = []
+        for idx in range(len(offsets)):
+            pred_id = int(probs[idx].argmax().item())
+            labels.append(id2label.get(pred_id, "O"))
+            scores.append(float(probs[idx][pred_id].item()))
+
+        for span in decode_ner_spans(
+            offsets,
+            labels=labels,
+            scores=scores,
+            threshold=self._threshold,
+        ):
+            key = (span.start, span.end)
+            if key in covered:
+                continue
+            subcategory = self._entity_to_subcategory(span.entity)
+            pf_label = self._pf_label_map.get(subcategory, "private_other")
+            extra.append(
+                Finding(
+                    category="leakage",
+                    subcategory=pf_label,
+                    stage="privacy_filter",
+                    span_start=span.start,
+                    span_end=span.end,
+                    score=span.score,
+                    evidence=f"Privacy model detected {normalize_ner_label(span.entity)}",
+                    replacement=None,
+                )
+            )
+            covered.add(key)
+
+        return [*baseline, *extra]

--- a/sdk/src/unplug/core/privacy/model_filter.py
+++ b/sdk/src/unplug/core/privacy/model_filter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from threading import Lock
 from typing import TYPE_CHECKING
 
 from unplug.api.types import Finding
@@ -38,6 +39,7 @@ class TokenPrivacyFilter:
         self._tokenizer: PreTrainedTokenizerBase | None = None
         self._model: PreTrainedModel | None = None
         self._device: str | None = device
+        self._load_lock = Lock()
         if eager_load:
             self.load()
 
@@ -52,36 +54,43 @@ class TokenPrivacyFilter:
     def load(self) -> None:
         if self._model is not None:
             return
-        try:
-            import torch
-            from transformers import AutoModelForTokenClassification, AutoTokenizer
-        except ImportError as exc:
-            msg = (
-                "TokenPrivacyFilter requires transformers and torch; "
-                "install unplug-ai[ml] or server [ml] extra"
+        with self._load_lock:
+            if self._model is not None:
+                return
+            try:
+                import torch
+                from transformers import AutoModelForTokenClassification, AutoTokenizer
+            except ImportError as exc:
+                msg = (
+                    "TokenPrivacyFilter requires transformers and torch; "
+                    "install unplug-ai[ml] or server [ml] extra"
+                )
+                raise RuntimeError(msg) from exc
+
+            from unplug.ml.device import resolve_torch_device
+
+            source = self._model_source
+            path = Path(source)
+            load_kwargs = {"local_files_only": self._local_files_only}
+            if path.is_dir():
+                source = str(path)
+
+            self._tokenizer = AutoTokenizer.from_pretrained(source, **load_kwargs)
+            self._model = AutoModelForTokenClassification.from_pretrained(
+                source,
+                **load_kwargs,
+                use_safetensors=True,
+                torch_dtype=torch.float32,
             )
-            raise RuntimeError(msg) from exc
-
-        from unplug.ml.device import resolve_torch_device
-
-        source = self._model_source
-        path = Path(source)
-        load_kwargs = {"local_files_only": self._local_files_only}
-        if path.is_dir():
-            source = str(path)
-
-        self._tokenizer = AutoTokenizer.from_pretrained(source, **load_kwargs)
-        self._model = AutoModelForTokenClassification.from_pretrained(
-            source,
-            **load_kwargs,
-            use_safetensors=True,
-            torch_dtype=torch.float32,
-        )
-        device = resolve_torch_device(self._device)
-        self._model.to(device)
-        self._model.eval()
-        self._device = device
-        _logger.info("Loaded token privacy filter from %s on %s", self._model_source, device)
+            device = resolve_torch_device(self._device)
+            model_loaded = self._model
+            if model_loaded is None:
+                msg = "Privacy filter failed to load model"
+                raise RuntimeError(msg)
+            model_loaded.to(device)
+            model_loaded.eval()
+            self._device = device
+            _logger.info("Loaded token privacy filter from %s on %s", self._model_source, device)
 
     def unload(self) -> None:
         self._model = None
@@ -106,7 +115,7 @@ class TokenPrivacyFilter:
         covered = {(f.span_start, f.span_end) for f in baseline}
         extra: list[Finding] = []
 
-        encoding = self._tokenizer(
+        encoding = tokenizer(
             text,
             return_offsets_mapping=True,
             truncation=True,
@@ -120,7 +129,11 @@ class TokenPrivacyFilter:
             logits = model(**model_inputs).logits[0]
 
         probs = torch.softmax(logits, dim=-1)
-        id2label = {int(k): str(v) for k, v in model.config.id2label.items()}
+        id2label_raw = model.config.id2label
+        if id2label_raw is None:
+            msg = "Privacy model missing id2label mapping"
+            raise RuntimeError(msg)
+        id2label = {int(k): str(v) for k, v in id2label_raw.items()}
         labels: list[str] = []
         scores: list[float] = []
         for idx in range(len(offsets)):

--- a/sdk/src/unplug/core/privacy/ner_decode.py
+++ b/sdk/src/unplug/core/privacy/ner_decode.py
@@ -1,0 +1,73 @@
+"""Decode token-classification NER tags into character spans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class NerCharSpan:
+    start: int
+    end: int
+    entity: str
+    score: float
+
+
+def normalize_ner_label(label: str) -> str:
+    """Strip BIO/BIOES prefix and return uppercase entity name or O."""
+    tag = label.strip().upper()
+    if tag in {"O", "OUTSIDE", "OTHER"}:
+        return "O"
+    if "-" in tag:
+        prefix, entity = tag.split("-", 1)
+        if prefix in {"B", "I", "E", "S"}:
+            return entity.strip().upper() or "O"
+    return tag
+
+
+def decode_ner_spans(
+    offset_mapping: list[tuple[int, int]],
+    *,
+    labels: list[str],
+    scores: list[float],
+    threshold: float,
+) -> list[NerCharSpan]:
+    """Merge per-token NER predictions into character spans."""
+    spans: list[NerCharSpan] = []
+    current: NerCharSpan | None = None
+
+    for (start, end), raw_label, score in zip(offset_mapping, labels, scores, strict=True):
+        if start == end == 0:
+            continue
+        entity = normalize_ner_label(raw_label)
+        conf = float(score)
+        if entity == "O" or conf < threshold:
+            if current is not None:
+                spans.append(current)
+                current = None
+            continue
+
+        prefix = raw_label.strip().upper().split("-", 1)[0] if "-" in raw_label else ""
+        starts_new = prefix in {"B", "S"} or current is None or current.entity != entity
+
+        if starts_new:
+            if current is not None:
+                spans.append(current)
+            current = NerCharSpan(start=start, end=end, entity=entity, score=conf)
+        elif current is not None:
+            current = NerCharSpan(
+                start=current.start,
+                end=end,
+                entity=entity,
+                score=max(current.score, conf),
+            )
+        else:
+            current = NerCharSpan(start=start, end=end, entity=entity, score=conf)
+
+        if prefix in {"E", "S"} and current is not None:
+            spans.append(current)
+            current = None
+
+    if current is not None:
+        spans.append(current)
+    return spans

--- a/sdk/src/unplug/core/privacy/privacy.py
+++ b/sdk/src/unplug/core/privacy/privacy.py
@@ -72,6 +72,7 @@ def build_privacy_filter(
     dev_heuristic: bool = False,
     model_source: str | None = None,
     threshold: float = 0.5,
+    max_length: int = 512,
     device: str | None = None,
     local_files_only: bool = False,
     eager_load: bool = True,
@@ -85,6 +86,7 @@ def build_privacy_filter(
         return TokenPrivacyFilter(
             model_source,
             threshold=threshold,
+            max_length=max_length,
             device=device,
             local_files_only=local_files_only,
             eager_load=eager_load,

--- a/sdk/src/unplug/core/privacy/privacy.py
+++ b/sdk/src/unplug/core/privacy/privacy.py
@@ -66,14 +66,32 @@ class HeuristicPrivacyFilter:
         return [*baseline, *extra]
 
 
-def build_privacy_filter(*, enabled: bool, dev_heuristic: bool = False) -> PrivacyFilterService:
-    """Build privacy filter stage. SDK uses heuristic only when explicitly requested."""
+def build_privacy_filter(
+    *,
+    enabled: bool,
+    dev_heuristic: bool = False,
+    model_source: str | None = None,
+    threshold: float = 0.5,
+    device: str | None = None,
+    local_files_only: bool = False,
+    eager_load: bool = True,
+) -> PrivacyFilterService:
+    """Build privacy filter stage for server or SDK."""
     if not enabled:
         return NullPrivacyFilter()
+    if model_source:
+        from unplug.core.privacy.model_filter import TokenPrivacyFilter
+
+        return TokenPrivacyFilter(
+            model_source,
+            threshold=threshold,
+            device=device,
+            local_files_only=local_files_only,
+            eager_load=eager_load,
+        )
     if dev_heuristic:
         return HeuristicPrivacyFilter()
     _logger.warning(
-        "privacy_filter_enabled without dev_heuristic; using NullPrivacyFilter until "
-        "unplug-safeguard model ships"
+        "privacy_filter_enabled without model_source or dev_heuristic; using NullPrivacyFilter"
     )
     return NullPrivacyFilter()

--- a/sdk/src/unplug/data/maps/privacy_entity_labels.toml
+++ b/sdk/src/unplug/data/maps/privacy_entity_labels.toml
@@ -1,0 +1,28 @@
+# Map token-classification entity labels → leakage scanner subcategories.
+# Keys are normalized to uppercase without B-/I-/E-/S- prefixes.
+
+[entities]
+EMAIL = { subcategory = "email_address" }
+EMAIL_ADDRESS = { subcategory = "email_address" }
+PHONE = { subcategory = "phone_number" }
+PHONE_NUMBER = { subcategory = "phone_number" }
+SSN = { subcategory = "ssn" }
+SOCIAL_SECURITY_NUMBER = { subcategory = "ssn" }
+CREDIT_CARD = { subcategory = "credit_card" }
+CREDITCARD = { subcategory = "credit_card" }
+PASSWORD = { subcategory = "api_key_generic" }
+API_KEY = { subcategory = "api_key_generic" }
+SECRET = { subcategory = "api_key_generic" }
+IP_ADDRESS = { subcategory = "private_other" }
+IP = { subcategory = "private_other" }
+ADDRESS = { subcategory = "private_other" }
+LOCATION = { subcategory = "private_other" }
+LOC = { subcategory = "private_other" }
+GPE = { subcategory = "private_other" }
+ORG = { subcategory = "private_other" }
+ORGANIZATION = { subcategory = "private_other" }
+PER = { subcategory = "private_other" }
+PERSON = { subcategory = "private_other" }
+NAME = { subcategory = "private_other" }
+USERNAME = { subcategory = "private_other" }
+DEFAULT = { subcategory = "private_other" }

--- a/sdk/tests/integration/test_scan_pr_cli.py
+++ b/sdk/tests/integration/test_scan_pr_cli.py
@@ -23,9 +23,17 @@ def _write_agent_file(root: Path, name: str, body: str) -> Path:
 
 
 def test_no_changed_files_returns_zero(capsys: pytest.CaptureFixture[str]) -> None:
-    with patch.object(scan_pr, "changed_agent_files", return_value=[]):
+    seen: dict[str, str] = {}
+
+    def fake_changed_agent_files(base_ref: str, repo_root: Path) -> list[Path]:
+        _ = repo_root
+        seen["base_ref"] = base_ref
+        return []
+
+    with patch.object(scan_pr, "changed_agent_files", side_effect=fake_changed_agent_files):
         exit_code = scan_pr.main_argv([])
     assert exit_code == 0
+    assert seen["base_ref"] == "main"
     assert "No agent-related files" in capsys.readouterr().out
 
 

--- a/sdk/tests/unit/core/test_privacy_model_filter.py
+++ b/sdk/tests/unit/core/test_privacy_model_filter.py
@@ -1,0 +1,66 @@
+"""Unit tests for NER privacy span decoding and filter wiring."""
+
+from __future__ import annotations
+
+from unplug.api.types import Finding
+from unplug.core.privacy.ner_decode import decode_ner_spans, normalize_ner_label
+from unplug.core.privacy.privacy import NullPrivacyFilter, build_privacy_filter
+
+
+class TestNormalizeNerLabel:
+    def test_bio_prefix_stripped(self) -> None:
+        assert normalize_ner_label("B-EMAIL") == "EMAIL"
+        assert normalize_ner_label("I-PHONE") == "PHONE"
+
+    def test_outside_label(self) -> None:
+        assert normalize_ner_label("O") == "O"
+
+
+class TestDecodeNerSpans:
+    def test_merges_bio_email_span(self) -> None:
+        offsets = [(0, 0), (0, 5), (5, 12), (12, 12)]
+        labels = ["O", "B-EMAIL", "I-EMAIL", "O"]
+        scores = [0.0, 0.95, 0.93, 0.0]
+        spans = decode_ner_spans(offsets, labels=labels, scores=scores, threshold=0.5)
+        assert len(spans) == 1
+        assert spans[0].start == 0
+        assert spans[0].end == 12
+        assert spans[0].entity == "EMAIL"
+
+    def test_threshold_filters_low_confidence(self) -> None:
+        offsets = [(0, 4)]
+        labels = ["B-EMAIL"]
+        scores = [0.2]
+        spans = decode_ner_spans(offsets, labels=labels, scores=scores, threshold=0.5)
+        assert spans == []
+
+
+class TestBuildPrivacyFilter:
+    def test_disabled_returns_null(self) -> None:
+        pf = build_privacy_filter(enabled=False)
+        assert isinstance(pf, NullPrivacyFilter)
+
+    def test_dev_heuristic_loaded(self) -> None:
+        pf = build_privacy_filter(enabled=True, dev_heuristic=True)
+        assert pf.is_loaded is True
+
+    def test_enabled_without_model_returns_null(self) -> None:
+        pf = build_privacy_filter(enabled=True)
+        assert isinstance(pf, NullPrivacyFilter)
+        assert pf.is_loaded is False
+
+    def test_scan_preserves_baseline_when_null(self) -> None:
+        pf = build_privacy_filter(enabled=False)
+        baseline = [
+            Finding(
+                category="leakage",
+                subcategory="private_email",
+                stage="regex",
+                span_start=0,
+                span_end=5,
+                score=0.9,
+                evidence="regex",
+            )
+        ]
+        out = pf.scan("hello", baseline=baseline)
+        assert out == baseline


### PR DESCRIPTION
## Summary
- Add `degraded` and `degraded_layers` to `ScanResult` for server/MCP degradation reporting.
- Add token-classification privacy filter support and NER label mapping used by server privacy posture hardening.
- Align `unplug.cli.scan_pr` default base ref to `main` and cover it in tests.

## Test plan
- `uv run pytest sdk/tests/unit/core/test_privacy_model_filter.py sdk/tests/integration/test_scan_pr_cli.py -q`

Closes #41