### PR TITLE
Restore PYPI_TOKEN publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,8 +1,8 @@
 name: Publish to PyPI
 
 # Releases run the full CI gate before building.
-# Auth: PyPI OIDC Trusted Publishing (no long-lived token). Configure the
-# trusted publisher for project "unplug-ai" in the PyPI project settings.
+# Auth: GitHub Environment "pypi" secret PYPI_TOKEN (uv publish).
+# Optional: configure PyPI Trusted Publishing for OIDC — see PUBLISH.md.
 
 on:
   release:
@@ -16,9 +16,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: pypi
-    permissions:
-      contents: read
-      id-token: write # required for PyPI OIDC Trusted Publishing
     defaults:
       run:
         working-directory: sdk
@@ -46,6 +43,6 @@ jobs:
         run: uv build
 
       - name: Publish unplug-ai
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          packages-dir: sdk/dist
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: uv publish --check-url https://pypi.org/pypi/unplug-ai/json


### PR DESCRIPTION
## Summary
- Revert publish step to `uv publish` with `PYPI_TOKEN` from the `pypi` environment
- OIDC trusted publishing was added in 05a2f3a but never configured on PyPI, blocking 0.4.0

## Test plan
- [ ] Merge and re-run **Publish to PyPI** workflow for v0.4.0