### PR TITLE
Release 0.4.1: integrations hub + live tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the `unplug-ai` SDK.
 
 ## [Unreleased]
 
+## [0.4.1] — 2026-06-25
+
+### Added
+
+- Agent-framework integration hub (`unplug.integrations.*`): framework-agnostic `AgentHooks` plus adapters for LangGraph, Agno, CrewAI, AutoGen, LlamaIndex, Pydantic AI, Semantic Kernel, and a custom-loop guide
+- Per-framework optional extras (`unplug-ai[langgraph]`, `[agno]`, `[crewai]`, `[autogen]`, `[llama-index]`, `[pydantic-ai]`, `[semantic-kernel]`, `[mcp]`) and an `integrations` meta-extra that installs them all
+- 40-angle agent security matrix (`tests/security/test_agent_integration_matrix.py`)
+- Live per-framework integration tests (`tests/optional/live/`) behind a dedicated `Integrations (live)` CI job (per-framework matrix, `requires_integrations` marker), with exit-5 tolerance for frameworks that are unimportable under our pinned deps
+- Integrations documentation hub under `integrations/` (per-framework guides + `TESTING.md`)
+
+### Changed
+
+- `all` extra now installs capability extras only (`ml,scrape,litellm,yara,haystack,presidio`); agent-framework adapters install via the `integrations` extra (or one at a time) so the core dependency tree and default CI matrix stay lean
+
 ## [0.4.0] — 2026-06-24
 
 ### Added

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unplug-ai"
-version = "0.4.0"
+version = "0.4.1"
 description = "Unplug the bad AI. Fast prompt injection detection and redaction for LLM apps, agents, and RAG pipelines."
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/unplug/__init__.py
+++ b/sdk/src/unplug/__init__.py
@@ -73,7 +73,7 @@ try:
     # Single source of truth is pyproject.toml; avoids version drift.
     __version__ = _pkg_version("unplug-ai")
 except PackageNotFoundError:  # not installed (e.g. running from a source checkout)
-    __version__ = "0.4.0"
+    __version__ = "0.4.1"
 
 
 def __getattr__(name: str) -> object:


### PR DESCRIPTION
## Summary

Cuts **0.4.1** to ship the agent-framework integrations landed in #46/#47.

- Bump `version` → `0.4.1` (pyproject + `__init__` source-checkout fallback)
- CHANGELOG `[0.4.1]`: integrations hub + adapters, per-framework extras + `integrations` meta-extra, 40-angle matrix, live CI job, `all` slimmed to capability extras

**Patch, not minor:** purely additive (new optional modules + extras). Staying `<0.5` keeps it inside every downstream pin (`unplug-ai>=0.4.0,<0.5`), avoiding a second four-repo re-pin train.

## Release steps after this merges
1. Merge `dev` → `main`
2. Tag + GitHub Release `v0.4.1` → triggers Publish to PyPI

## Test plan
- [x] Version strings consistent (pyproject + `__init__`)
- [x] `ruff check` clean
- [ ] Full CI green on `dev` (3.11/3.12/3.13)