### PR TITLE
Live integration tests: fresh per-framework resolution (fixes semantic-kernel)

### DIFF
--- a/.github/workflows/integrations-live.yml
+++ b/.github/workflows/integrations-live.yml
@@ -78,22 +78,28 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install (one framework extra in isolation)
-        run: uv sync --extra dev --extra ${{ matrix.extra }}
+      - name: Install (fresh per-framework resolution — matches `pip install "unplug-ai[extra]"`)
+        # Deliberately NOT `uv sync` from the unified lock: that lock co-resolves
+        # every extra together and pins some frameworks down to old, broken
+        # releases (e.g. semantic-kernel 1.15, which imports `Url` from
+        # `pydantic.networks` — gone in Pydantic v2). A user never installs all
+        # frameworks at once; they run `pip install "unplug-ai[langgraph]"`, which
+        # resolves that one framework freshly. We mirror that here.
+        run: |
+          uv venv
+          uv pip install -e ".[dev,${{ matrix.extra }}]"
 
       - name: Live integration test
         run: |
           set +e
-          uv run pytest -q -m requires_integrations ${{ matrix.test }}
+          .venv/bin/python -m pytest -q -m requires_integrations ${{ matrix.test }}
           rc=$?
           set -e
-          # Exit 5 = pytest collected nothing because the module self-skipped:
-          # the framework installed but is unimportable under our pinned deps
-          # (e.g. an upstream release incompatible with our Pydantic v2). That is
-          # an upstream conflict, not an Unplug regression — surface it loudly but
-          # don't block. Real test failures (exit 1) still fail the job.
+          # Exit 5 = the module self-skipped: the framework is unimportable even
+          # under a fresh resolution (a genuine upstream break). Surface it loudly
+          # but don't block the release. Real test failures (exit 1) still fail.
           if [ "$rc" -eq 5 ]; then
-            echo "::warning title=Live integration skipped::${{ matrix.extra }} installed but its live tests were skipped (framework unimportable under current deps). Tolerated; not blocking."
+            echo "::warning title=Live integration skipped::${{ matrix.extra }} installed but its live tests were skipped (framework unimportable under a fresh resolution). Tolerated; not blocking."
             exit 0
           fi
           exit $rc

--- a/sdk/integrations/TESTING.md
+++ b/sdk/integrations/TESTING.md
@@ -115,31 +115,36 @@ These run in the dedicated **`Integrations (live)`** workflow
 nightly (06:00 UTC), and via manual dispatch — keeping the everyday PR gate fast while
 still catching framework drift.
 
-Run one framework locally (installs just that extra):
+**Fresh resolution, on purpose.** Each leg runs `uv pip install -e ".[dev,<extra>]"`, *not*
+`uv sync`. The unified `uv.lock` co-resolves every extra together and pins some frameworks to
+old releases (e.g. `semantic-kernel` 1.15, which imports `Url` from `pydantic.networks` —
+removed in Pydantic v2). No user installs every framework at once; they run
+`pip install "unplug-ai[semantic-kernel]"`, which resolves that one framework freshly (→ 1.36,
+which works). We mirror the user path. The `-e` (editable) keeps the source tree on `sys.path`
+so test-only assets like `configs/ml_validation.json` resolve.
+
+Run one framework locally the same way CI does (latest compatible version of that extra):
 
 ```bash
 cd sdk
-uv sync --extra dev --extra langgraph
-uv run pytest -q -m requires_integrations tests/optional/live/test_langgraph_live.py
-```
-
-Run every live test you have frameworks for (installs all agent SDKs):
-
-```bash
-uv sync --extra dev --extra integrations
-uv run pytest -q -m requires_integrations tests/optional/live/
+uv venv /tmp/unplug-lg && uv pip install --python /tmp/unplug-lg -e ".[dev,langgraph]"
+/tmp/unplug-lg/bin/python -m pytest -q -m requires_integrations tests/optional/live/test_langgraph_live.py
 ```
 
 > Live tests never call an LLM. They build the smallest real framework object and assert the
 > Unplug guard's decision (block on injection / destructive tool, allow benign), so they stay
 > hermetic and need no API keys.
 
-**Tolerated skips.** Each leg installs its framework, so a test that runs and fails is a real
-regression. But some optional frameworks ship releases that are unimportable under our pinned
-core deps (e.g. a `semantic-kernel` build that imports `Url` from `pydantic.networks`, removed
-in Pydantic v2). When that happens the module `importorskip`s, pytest exits `5` ("no tests
-ran"), and the job emits a non-blocking `::warning::` rather than failing — that is an upstream
-conflict, not an Unplug bug. Genuine test failures (exit `1`) still fail the job.
+**Verified compatible (2026-06-25)** against latest releases: LangGraph 1.2.6, Agno 2.6.19,
+CrewAI 1.14.7, AutoGen-AgentChat 0.7.5, LlamaIndex-core 0.14.23, Pydantic AI 2.0.0,
+Semantic Kernel 1.36.0. (Most adapters are framework-agnostic — they wrap `AgentHooks` and
+never import the framework — so they are robust across major version bumps.)
+
+**Tolerated skips (safety net).** Each leg installs its framework, so a test that runs and
+fails is a real regression. If a future upstream release becomes genuinely unimportable even
+under a fresh resolution, the module `importorskip`s, pytest exits `5` ("no tests ran"), and
+the job emits a non-blocking `::warning::` rather than failing. Genuine failures (exit `1`)
+still fail the job.
 
 ## CI markers
 

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -27,7 +27,14 @@ def pytest_configure(config: object) -> None:
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    if resolve_validation_checkpoint(require_weights=True) is None:
+    try:
+        weights_available = resolve_validation_checkpoint(require_weights=True) is not None
+    except FileNotFoundError:
+        # No ML validation manifest on disk (e.g. running the suite against a
+        # non-editable/wheel install where configs/ are not packaged). Treat as
+        # "no weights" and skip ML-gated tests instead of crashing collection.
+        weights_available = False
+    if not weights_available:
         skip_ml = pytest.mark.skip(reason="ML checkpoint weights not available")
         for item in items:
             if "requires_ml_weights" in item.keywords:


### PR DESCRIPTION
## Why

The `Integrations (live)` job installed each framework with `uv sync --extra dev --extra <x>`, which resolves from the **unified `uv.lock`**. That lock co-resolves *every* extra together and pins some frameworks to old releases — notably **semantic-kernel 1.15**, which does `from pydantic.networks import Url` (removed in Pydantic v2) and is therefore unimportable. The leg "passed" only because it self-skipped (exit 5, tolerated).

But no user installs every framework at once. A user runs `pip install "unplug-ai[semantic-kernel]"`, which resolves that one framework **freshly → 1.36.0**, and it works.

## What

- **Live job now mirrors the user path**: `uv pip install -e ".[dev,<extra>]"` (fresh per-framework resolution) instead of `uv sync` from the kitchen-sink lock. `-e` keeps the source tree on `sys.path` so test-only assets (`configs/ml_validation.json`) resolve.
- **Hardened `tests/conftest.py`**: the collection hook caught `FileNotFoundError` from a missing ML manifest instead of crashing pytest with an `INTERNALERROR` (rc=3) on non-editable installs.
- Docs (`integrations/TESTING.md`) updated: rationale + verified-compatible version table.
- `uv.lock`: editable self-version `0.4.0 → 0.4.1` (stray re-lock, correct).

## Verified locally (fresh, editable install — latest releases)

| Framework | Version | Live test |
|---|---|---|
| LangGraph | 1.2.6 | ✅ 4 passed |
| Agno | 2.6.19 | ✅ 5 passed |
| CrewAI | 1.14.7 | ✅ 5 passed |
| AutoGen-AgentChat | 0.7.5 | ✅ 4 passed |
| LlamaIndex-core | 0.14.23 | ✅ 2 passed |
| Pydantic AI | 2.0.0 | ✅ 6 passed |
| Semantic Kernel | 1.36.0 | ✅ 5 passed |

No shipped-package change — `unplug-ai 0.4.1` on PyPI is already compatible with all seven. This only makes CI honest.

## Test plan
- [ ] `Integrations (live)` matrix is green (all 7 legs run real tests, none tolerated-skipped)
- [ ] Core CI unaffected