### PR TITLE
harden(scan_pr): fail-closed base-ref, overlapping chunks, .github agent files

### DIFF
--- a/sdk/src/unplug/cli/scan_pr.py
+++ b/sdk/src/unplug/cli/scan_pr.py
@@ -17,7 +17,6 @@ _SKIP_PREFIXES = (
     "docs/",
     "examples/",
     "demo/",
-    ".github/",
     ".context/",
 )
 _AGENT_MARKERS = (
@@ -27,8 +26,30 @@ _AGENT_MARKERS = (
     "mcp.json",
     "claude_desktop_config",
     ".mcp/",
+    "copilot-instructions",
+    ".github/agents/",
 )
 _MAX_CHUNK = 2000
+_CHUNK_OVERLAP = 200
+
+
+def _is_agent_file(rel: str) -> bool:
+    """True if a repo-relative path looks like in-scope agent/MCP configuration."""
+    if not rel or any(rel.startswith(p) for p in _SKIP_PREFIXES):
+        return False
+    rel_posix = rel.replace("\\", "/")
+    return any(marker in rel_posix for marker in _AGENT_MARKERS)
+
+
+def base_ref_exists(base_ref: str, repo_root: Path) -> bool:
+    """True if origin/<base_ref> resolves to a commit (needs a fetch-depth: 0 checkout)."""
+    result = subprocess.run(  # noqa: S603
+        ["git", "rev-parse", "--verify", "--quiet", f"origin/{base_ref}^{{commit}}"],  # noqa: S607
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
 
 
 def changed_agent_files(base_ref: str, repo_root: Path) -> list[Path]:
@@ -43,20 +64,23 @@ def changed_agent_files(base_ref: str, repo_root: Path) -> list[Path]:
     paths: list[Path] = []
     for line in out.splitlines():
         rel = line.strip()
-        if not rel or any(rel.startswith(p) for p in _SKIP_PREFIXES):
+        if not _is_agent_file(rel):
             continue
         path = repo_root / rel
         if not path.is_file():
             continue
-        rel_posix = rel.replace("\\", "/")
-        if any(marker in rel_posix for marker in _AGENT_MARKERS):
-            paths.append(path)
+        paths.append(path)
     return paths
 
 
 def _chunks(text: str) -> list[str]:
+    """Overlapping windows so an injection straddling a chunk boundary is still
+    wholly contained in at least one chunk."""
     text = text[:50_000]
-    return [text[i : i + _MAX_CHUNK] for i in range(0, len(text), _MAX_CHUNK)] or [text]
+    if len(text) <= _MAX_CHUNK:
+        return [text]
+    step = _MAX_CHUNK - _CHUNK_OVERLAP
+    return [text[i : i + _MAX_CHUNK] for i in range(0, len(text), step)]
 
 
 def scan_paths(repo_root: Path, paths: list[Path]) -> list[tuple[Path, str]]:
@@ -100,6 +124,13 @@ def main_argv(argv: list[str] | None = None) -> int:
 
     if args.paths:
         paths = [p if p.is_absolute() else repo_root / p for p in args.paths]
+    elif not base_ref_exists(args.base_ref, repo_root):
+        print(
+            f"::error::Base ref 'origin/{args.base_ref}' not found. Check out with full history "
+            "(fetch-depth: 0) and pass the correct --base-ref; refusing to scan a possibly-empty "
+            "diff."
+        )
+        return 2
     else:
         paths = changed_agent_files(args.base_ref, repo_root)
 

--- a/sdk/tests/integration/test_scan_pr_cli.py
+++ b/sdk/tests/integration/test_scan_pr_cli.py
@@ -30,11 +30,41 @@ def test_no_changed_files_returns_zero(capsys: pytest.CaptureFixture[str]) -> No
         seen["base_ref"] = base_ref
         return []
 
-    with patch.object(scan_pr, "changed_agent_files", side_effect=fake_changed_agent_files):
+    with (
+        patch.object(scan_pr, "base_ref_exists", return_value=True),
+        patch.object(scan_pr, "changed_agent_files", side_effect=fake_changed_agent_files),
+    ):
         exit_code = scan_pr.main_argv([])
     assert exit_code == 0
     assert seen["base_ref"] == "main"
     assert "No agent-related files" in capsys.readouterr().out
+
+
+def test_missing_base_ref_fails_closed(capsys: pytest.CaptureFixture[str]) -> None:
+    with patch.object(scan_pr, "base_ref_exists", return_value=False):
+        exit_code = scan_pr.main_argv([])
+    assert exit_code == 2
+    out = capsys.readouterr().out
+    assert "::error::" in out
+    assert "not found" in out
+
+
+def test_chunks_overlap_keeps_boundary_phrase_intact() -> None:
+    phrase = "ignore all previous instructions"
+    # Position the phrase so it straddles the first 2000-char window boundary.
+    prefix = "a" * (2000 - len(phrase) // 2)
+    text = prefix + phrase + "b" * 3000
+    chunks = scan_pr._chunks(text)
+    assert any(phrase in chunk for chunk in chunks)
+
+
+def test_github_agent_files_are_in_scope() -> None:
+    assert scan_pr._is_agent_file(".github/copilot-instructions.md") is True
+    assert scan_pr._is_agent_file(".github/agents/reviewer.md") is True
+    assert scan_pr._is_agent_file(".cursor/rules") is True
+    # Non-agent files stay out of scope even when they live under .github/.
+    assert scan_pr._is_agent_file(".github/workflows/ci.yml") is False
+    assert scan_pr._is_agent_file("tests/test_x.py") is False
 
 
 def test_clean_agent_file_returns_zero(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes the deeper fail-open surface in the PR scanner CLI flagged in the cross-repo review (companion to UnplugAI/unplug-scan-action#5, which adds an action-level base-ref preflight). These take effect for the action on the next SDK release.

## Fixes
1. **Fail closed on a missing base ref.** `main_argv` now checks `git rev-parse origin/<base-ref>` and returns exit **2** with a clear `::error::` when it's absent (shallow checkout / wrong branch), instead of letting an empty/incorrect diff scan silently pass.
2. **Overlapping chunks.** `_chunks` now uses a 200-char sliding overlap so an injection straddling a 2000-char boundary is wholly contained in at least one chunk (previously could be split and missed).
3. **`.github/` no longer blanket-skipped.** Removed `.github/` from the skip list and added `copilot-instructions` + `.github/agents/` markers, so agent-instruction files living under `.github/` are scanned. Non-agent files (e.g. `.github/workflows/*.yml`) still stay out of scope via the marker filter.

Extracted a pure `_is_agent_file()` helper for direct testing.

## Tests (8 passed; ruff + format clean)
- `test_missing_base_ref_fails_closed` → exit 2 + `::error::`
- `test_chunks_overlap_keeps_boundary_phrase_intact`
- `test_github_agent_files_are_in_scope` (incl. `.github/workflows/ci.yml` stays out)
- existing exit-code contract tests still pass