### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the `unplug-ai` SDK.
 
-## [Unreleased]
+## [0.5.0] — 2026-06-27
 
 ### Added
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unplug-ai"
-version = "0.4.1"
+version = "0.5.0"
 description = "Unplug the bad AI. Fast prompt injection detection and redaction for LLM apps, agents, and RAG pipelines."
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/unplug/__init__.py
+++ b/sdk/src/unplug/__init__.py
@@ -73,7 +73,7 @@ try:
     # Single source of truth is pyproject.toml; avoids version drift.
     __version__ = _pkg_version("unplug-ai")
 except PackageNotFoundError:  # not installed (e.g. running from a source checkout)
-    __version__ = "0.4.1"
+    __version__ = "0.5.0"
 
 
 def __getattr__(name: str) -> object:

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -6910,7 +6910,7 @@ wheels = [
 
 [[package]]
 name = "unplug-ai"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Cuts **unplug-ai 0.5.0** (minor bump from 0.4.1). All shipping content is already merged on `dev` via #53 and #56.

- `version` 0.4.1 → 0.5.0 (`pyproject.toml`, `__init__.py` fallback, `uv.lock`)
- CHANGELOG `[Unreleased]` → `[0.5.0] — 2026-06-27`

### What's in 0.5.0 (since 0.4.1)
- **Ten** agent-framework integrations: OpenAI Agents SDK, LangChain, Google ADK, smolagents, DSPy, Strands, Letta (#53) + Griptape, AG2, Atomic Agents (#56)
- Per-framework extras + `integrations` meta-extra; per-framework guides + runnable demos
- Security matrix expanded **40 → 72 angles**; per-framework live CI legs

## Release flow
After merge: fast-forward `dev` → `main`, then publish a GitHub Release `v0.5.0` (triggers `publish-pypi.yml` → `make check-ci` → `uv build` → `uv publish`).

## Test plan
- [x] `uv build` produces `unplug_ai-0.5.0` wheel + sdist
- [x] `import unplug` OK; security matrix green locally
- [ ] PR CI (ci.yml + Integrations live) green