### PR TITLE
Pin model catalog to immutable Hugging Face revisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the `unplug-ai` SDK.
 
 ## [Unreleased]
 
+### Security
+
+- Pin bundled model catalog to immutable Hugging Face commit SHAs under `Unplug-AI/`; drop unpublished medium/large tiers that pointed at a non-existent org
+
 ### Added
 
 - Beginner onboarding: [`sdk/docs/GETTING_STARTED.md`](sdk/docs/GETTING_STARTED.md) (5-minute path)

--- a/sdk/src/unplug/cli/models.py
+++ b/sdk/src/unplug/cli/models.py
@@ -77,12 +77,12 @@ def main() -> None:
     list_p.set_defaults(func=_cmd_list)
 
     dl_p = sub.add_parser("download", help="Download a tier from Hugging Face")
-    dl_p.add_argument("tier", nargs="?", help="tiny | medium | large (default: catalog default)")
+    dl_p.add_argument("tier", nargs="?", help="catalog tier (default: catalog default)")
     dl_p.add_argument("--force", action="store_true", help="Re-download even if cached")
     dl_p.set_defaults(func=_cmd_download)
 
     up_p = sub.add_parser("upgrade", help="Re-download tier to pick up catalog revision")
-    up_p.add_argument("tier", nargs="?", help="tiny | medium | large")
+    up_p.add_argument("tier", nargs="?", help="catalog tier (default: catalog default)")
 
     def _upgrade_cmd(a: argparse.Namespace) -> int:
         return _cmd_download(argparse.Namespace(**{**vars(a), "force": True}))

--- a/sdk/src/unplug/config/guard.py
+++ b/sdk/src/unplug/config/guard.py
@@ -117,7 +117,7 @@ class GuardConfig(BaseModel):
     )
     active_model: str | None = Field(
         default=None,
-        description="Model tier key: tiny, medium, or large (see data/catalog.toml)",
+        description="Model tier key from data/catalog.toml (default tier: tiny)",
     )
     auto_download_model: bool = Field(
         default=False,

--- a/sdk/src/unplug/data/catalog.toml
+++ b/sdk/src/unplug/data/catalog.toml
@@ -8,7 +8,7 @@ default_tier = "tiny"
 [catalog.tiers.tiny]
 name = "unplug-tiny"
 repo_id = "Unplug-AI/unplug-tiny-v1"
-revision = "19b7d6701bea"
+revision = "19b7d6701bea1f6d9f03ec7bcaeeea390dff43be"
 backend = "transformers_span"
 description = "Default dual-head span injection model (DeBERTa-v3-xsmall)"
 
@@ -28,31 +28,3 @@ long_text_mode = "sliding"
 long_text_threshold_chars = 8192
 long_text_chunk_chars = 2048
 long_text_overlap_chars = 256
-
-[catalog.tiers.medium]
-name = "unplug-medium"
-repo_id = "UnplugAI/unplug-medium"
-revision = "main"
-backend = "transformers_span"
-description = "Higher-capacity injection model (future release)"
-
-[catalog.tiers.medium.config]
-inj_threshold = 0.45
-doc_threshold = 0.9
-max_length = 512
-stride = 64
-device = "auto"
-
-[catalog.tiers.large]
-name = "unplug-large"
-repo_id = "UnplugAI/unplug-large"
-revision = "main"
-backend = "transformers_span"
-description = "Largest injection model tier (future release)"
-
-[catalog.tiers.large.config]
-inj_threshold = 0.45
-doc_threshold = 0.9
-max_length = 512
-stride = 64
-device = "auto"

--- a/sdk/src/unplug/ml/catalog.py
+++ b/sdk/src/unplug/ml/catalog.py
@@ -1,4 +1,4 @@
-"""Load bundled model tier catalog (tiny / medium / large)."""
+"""Load bundled model tier catalog from data/catalog.toml."""
 
 from __future__ import annotations
 

--- a/sdk/tests/unit/ml/test_catalog.py
+++ b/sdk/tests/unit/ml/test_catalog.py
@@ -1,0 +1,27 @@
+"""Offline invariants for the bundled model catalog."""
+
+from __future__ import annotations
+
+import re
+
+from unplug.ml.catalog import load_catalog
+
+_FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+_REPO_PREFIX = "Unplug-AI/"
+
+
+def test_catalog_revisions_are_full_commit_shas() -> None:
+    cat = load_catalog()
+    assert cat.tiers, "catalog must define at least one tier"
+    for tier_id, entry in cat.tiers.items():
+        assert _FULL_SHA.match(entry.revision), (
+            f"tier {tier_id!r}: revision must be a 40-char hex SHA, got {entry.revision!r}"
+        )
+
+
+def test_catalog_repo_ids_use_official_org() -> None:
+    cat = load_catalog()
+    for tier_id, entry in cat.tiers.items():
+        assert entry.repo_id.startswith(_REPO_PREFIX), (
+            f"tier {tier_id!r}: repo_id must start with {_REPO_PREFIX!r}, got {entry.repo_id!r}"
+        )

--- a/sdk/tests/unit/ml/test_model_store.py
+++ b/sdk/tests/unit/ml/test_model_store.py
@@ -116,7 +116,7 @@ def test_list_status_includes_all_tiers(tmp_path: Path) -> None:
     store = ModelStore(cache_root=tmp_path)
     rows = store.list_status()
     tiers = {r["tier"] for r in rows}
-    assert {"tiny", "medium", "large"}.issubset(tiers)
+    assert tiers == set(load_catalog().tier_names())
 
 
 def test_guard_survives_corrupt_checkpoint(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Pin `Unplug-AI/unplug-tiny-v1` to full commit SHA `19b7d6701bea1f6d9f03ec7bcaeeea390dff43be` (was a 12-char short hash).
- Remove `medium` and `large` catalog tiers: they pointed at the non-existent `UnplugAI` org with mutable `revision = "main"`. Verified via the Hugging Face API that only `Unplug-AI/unplug-tiny-v1` exists under the real org today.
- Add offline catalog invariant tests (40-char hex SHA + `Unplug-AI/` repo prefix).

## Test plan

- [x] `make check` from `sdk/` (ruff, mypy, format, pytest — 1000 passed)
- [x] New `tests/unit/ml/test_catalog.py` asserts revision/org invariants on shipped TOML
- [ ] Manual: `unplug-models list` shows only `tiny` tier with pinned SHA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Supply-chain and download pinning changes are security-positive, but removing `medium`/`large` can break configs or scripts that still reference those tier keys.
> 
> **Overview**
> **Hardens the bundled model catalog** so downloads always target a fixed Hugging Face commit under the real `Unplug-AI/` org, and removes placeholder tiers that pointed at the wrong org with mutable `main` revisions.
> 
> `catalog.toml` now pins `unplug-tiny-v1` to the full 40-character SHA (replacing a 12-character short hash). The `medium` and `large` entries are removed entirely, leaving `tiny` as the only shipped tier. Docs and CLI copy (`unplug-models`, `GuardConfig.active_model`) no longer imply a fixed `tiny | medium | large` set.
> 
> New offline tests in `test_catalog.py` enforce that every tier uses a 40-char hex revision and a `Unplug-AI/` repo prefix; `test_model_store` asserts `list_status()` tiers match `load_catalog().tier_names()` instead of a hardcoded three-tier set. **CHANGELOG** records this under **Security**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c9df7359a3bac307e464411bb23e9cfbe7145df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->