### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to the `unplug-ai` SDK.
 
-## [Unreleased]
+## [0.5.1] — 2026-07-20
+
+### Fixed
+
+- Python 3.13: `unplug-ai[ml]` / `[all]` install without a Rust toolchain — widen `transformers` constraint to `>=4.44,<5.13` so `tokenizers` resolves to a cp313 wheel (was pinned via `transformers>=4.44,<4.45` → `tokenizers==0.19.1`)
 
 ### Security
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unplug-ai"
-version = "0.5.0"
+version = "0.5.1"
 description = "Unplug the bad AI. Fast prompt injection detection and redaction for LLM apps, agents, and RAG pipelines."
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/unplug/__init__.py
+++ b/sdk/src/unplug/__init__.py
@@ -73,7 +73,7 @@ try:
     # Single source of truth is pyproject.toml; avoids version drift.
     __version__ = _pkg_version("unplug-ai")
 except PackageNotFoundError:  # not installed (e.g. running from a source checkout)
-    __version__ = "0.5.0"
+    __version__ = "0.5.1"
 
 
 def __getattr__(name: str) -> object:

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -6910,7 +6910,7 @@ wheels = [
 
 [[package]]
 name = "unplug-ai"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Cuts **unplug-ai 0.5.1** (patch from 0.5.0). Shipping content is already on `dev` (#55 transformers widen, #68 catalog pins, plus docs/API work since 0.5.0).

- `version` 0.5.0 → 0.5.1 (`pyproject.toml`, `__init__.py` fallback, `uv.lock`)
- CHANGELOG `[Unreleased]` → `[0.5.1] — 2026-07-20` (adds Fixed for the Python 3.13 `[ml]` install break)

### What's in 0.5.1 (since 0.5.0)
- **Fixed:** Python 3.13 `unplug-ai[ml]` / `[all]` install without a Rust toolchain (`transformers>=4.44,<5.13`)
- **Security:** Model catalog pinned to immutable Hugging Face commit SHAs under `Unplug-AI/`; unpublished medium/large tiers removed (#68)
- Docs/UX onboarding, public API facades + coverage gate (#60, #67)

## Release flow
After merge: promote `dev` → `main`, then publish GitHub Release `v0.5.1` (triggers `publish-pypi.yml` → `make check-ci` → `uv build` → `uv publish`).

## Test plan
- [x] `make check-ci` green locally
- [ ] PR CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no behavioral code modifications in the diff.
> 
> **Overview**
> **Release 0.5.1** — bumps package version from **0.5.0** to **0.5.1** in `pyproject.toml`, the `__init__.py` install-metadata fallback, and `uv.lock`.
> 
> **CHANGELOG** moves unreleased notes into **`[0.5.1] — 2026-07-20`**, including a new **Fixed** entry for Python 3.13 installs of `unplug-ai[ml]` / `[all]` (wider `transformers` constraint so `tokenizers` resolves to a cp313 wheel without a Rust build).
> 
> No runtime or API changes in this diff; it tags and documents work already on `dev` for PyPI/GitHub release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d02e911016c3c2f41fa5ffba3c17e547ad77463. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->