### PR TITLE
Harden model store and guard ML init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `unplug-ai` SDK.
 
+## [Unreleased]
+
+### Fixed
+
+- Model store hardening: corrupt manifests no longer crash Guard or `unplug-models`; checkpoint validation requires weight files; atomic manifest writes and download swaps preserve existing installs on failure; `list_status` correctly reports stale revisions as upgrade-available; invalid `UNPLUG_MODEL_PATH` logs a warning; CLI download errors distinguish missing ML extras from network/repo failures
+
+### Changed
+
+- Unknown `active_model` tier names now raise `ConfigError` with valid catalog tiers instead of silently running without ML
+
 ## [0.5.1] — 2026-07-20
 
 ### Fixed

--- a/sdk/src/unplug/cli/models.py
+++ b/sdk/src/unplug/cli/models.py
@@ -12,6 +12,19 @@ from unplug.ml.catalog import load_catalog
 from unplug.ml.store import ModelStore
 
 
+def _hf_error_hint(exc: BaseException) -> str | None:
+    module = type(exc).__module__
+    if module.startswith("huggingface_hub"):
+        return (
+            "Check network access and that the Hugging Face repo/revision exists "
+            "for this catalog tier."
+        )
+    cause = exc.__cause__
+    if cause is not None and cause is not exc:
+        return _hf_error_hint(cause)
+    return None
+
+
 def _cmd_list(args: argparse.Namespace) -> int:
     store = ModelStore()
     rows = store.list_status()
@@ -43,13 +56,20 @@ def _cmd_download(args: argparse.Namespace) -> int:
     except (ConfigError, ModelError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
-    except Exception as exc:
+    except ImportError as exc:
         print(
             f"Error: {exc}\n"
             f"Install ML extras: pip install 'unplug-ai[ml]'\n"
             f"Or set UNPLUG_MODEL_PATH to a local checkpoint directory.",
             file=sys.stderr,
         )
+        return 1
+    except Exception as exc:
+        hint = _hf_error_hint(exc)
+        if hint is not None:
+            print(f"Error: {exc}\n{hint}", file=sys.stderr)
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
         return 1
     print(f"Downloaded {tier} → {path}")
     return 0

--- a/sdk/src/unplug/core/runtime/model_runtime.py
+++ b/sdk/src/unplug/core/runtime/model_runtime.py
@@ -32,7 +32,11 @@ def resolve_active_model_spec(config: GuardConfig) -> ModelSpec | None:
     if spec is None:
         fallback = catalog_model_spec(config.active_model)
         if fallback is None:
-            return None
+            cat = load_catalog()
+            valid = ", ".join(cat.tier_names())
+            raise ConfigError(
+                f"Unknown active_model tier {config.active_model!r}. Valid tiers: {valid}"
+            )
         spec = fallback
     if isinstance(spec, dict):
         spec = ModelSpec.model_validate(spec)
@@ -87,13 +91,17 @@ def build_model_registry() -> ModelRegistry:
     return registry
 
 
-def load_active_model_provider(config: GuardConfig) -> ModelProvider | None:
-    spec = prepare_active_model_spec(config)
-    if spec is None:
+def load_active_model_provider(
+    config: GuardConfig,
+    *,
+    spec: ModelSpec | None = None,
+) -> ModelProvider | None:
+    resolved = spec if spec is not None else prepare_active_model_spec(config)
+    if resolved is None:
         return None
-    if spec.backend == "null":
+    if resolved.backend == "null":
         return None
-    path = spec.path
+    path = resolved.path
     if not path or not Path(path).is_dir():
         if config.require_ml:
             tier = config.active_model or "unknown"
@@ -103,7 +111,7 @@ def load_active_model_provider(config: GuardConfig) -> ModelProvider | None:
             raise ModelError(msg)
         return None
     registry = build_model_registry()
-    return registry.get(spec)
+    return registry.get(resolved)
 
 
 def model_cache_version(spec: ModelSpec | None) -> str:

--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -162,48 +162,51 @@ class Guard:
         scanner_names = list(cfg.scanners)
         self._validate_optional_scanners(scanner_names)
         if cfg.mode != "server" and cfg.active_model:
-            spec = prepare_active_model_spec(cfg)
-            if spec is not None:
-                from unplug.exceptions import ModelError
+            from unplug.exceptions import ModelError
 
-                provider = None
-                load_error: Exception | None = None
-                try:
-                    provider = load_active_model_provider(cfg)
-                except Exception as exc:
-                    load_error = exc
-                    if cfg.require_ml:
-                        tier = cfg.active_model
-                        raise ModelError(
-                            f"require_ml=true but model tier {tier!r} could not be loaded: "
-                            f"{type(exc).__name__}: {exc}"
-                        ) from exc
-                    _log.warning(
-                        "active_model=%s configured but injection_ml failed to load (%s). "
-                        'Fix: pip install "unplug-ai[ml]", then unplug-models download %s '
-                        "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only.",
-                        cfg.active_model,
-                        type(exc).__name__,
-                        cfg.active_model,
-                    )
-                    self._ml_degraded = True
-                if provider is not None:
-                    self._ml_provider = provider
-                    self._model_cache_version = model_cache_version(spec)
-                elif cfg.require_ml:
+            provider = None
+            spec = None
+            load_error: Exception | None = None
+            try:
+                spec = prepare_active_model_spec(cfg)
+                if spec is not None:
+                    provider = load_active_model_provider(cfg, spec=spec)
+            except ConfigError:
+                raise
+            except Exception as exc:
+                load_error = exc
+                if cfg.require_ml:
+                    tier = cfg.active_model
                     raise ModelError(
-                        f"require_ml=true but model tier {cfg.active_model!r} could not be loaded. "
-                        f"Run: unplug-models download {cfg.active_model}"
-                    )
-                elif load_error is None:
-                    _log.warning(
-                        "active_model=%s configured but injection_ml is not loaded. "
-                        "Run: unplug-models download %s (or set UNPLUG_MODEL_PATH). "
-                        "Continuing with regex scanners only.",
-                        cfg.active_model,
-                        cfg.active_model,
-                    )
-                    self._ml_degraded = True
+                        f"require_ml=true but model tier {tier!r} could not be loaded: "
+                        f"{type(exc).__name__}: {exc}"
+                    ) from exc
+                _log.warning(
+                    "active_model=%s configured but injection_ml failed to load (%s). "
+                    'Fix: pip install "unplug-ai[ml]", then unplug-models download %s '
+                    "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only.",
+                    cfg.active_model,
+                    type(exc).__name__,
+                    cfg.active_model,
+                )
+                self._ml_degraded = True
+            if provider is not None and spec is not None:
+                self._ml_provider = provider
+                self._model_cache_version = model_cache_version(spec)
+            elif cfg.require_ml:
+                raise ModelError(
+                    f"require_ml=true but model tier {cfg.active_model!r} could not be loaded. "
+                    f"Run: unplug-models download {cfg.active_model}"
+                )
+            elif load_error is None:
+                _log.warning(
+                    "active_model=%s configured but injection_ml is not loaded. "
+                    'Fix: pip install "unplug-ai[ml]", then unplug-models download %s '
+                    "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only.",
+                    cfg.active_model,
+                    cfg.active_model,
+                )
+                self._ml_degraded = True
 
         v2_scanners = self._registry.get_many(scanner_names, configs=cfg.scanner_configs)
         if self._ml_provider is not None:

--- a/sdk/src/unplug/ml/store.py
+++ b/sdk/src/unplug/ml/store.py
@@ -10,12 +10,28 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
+from unplug.core.runtime.logging import get_logger
 from unplug.exceptions import ConfigError
 from unplug.ml.catalog import CatalogTier, load_catalog
 from unplug.ml.models import ModelSpec
 from unplug.optional.ml import require_huggingface_hub
+
+_log = get_logger("ml.store")
+
+_WEIGHT_FILES = ("model.safetensors", "pytorch_model.bin")
+
+_SNAPSHOT_ALLOW_PATTERNS = [
+    "*.json",
+    "*.safetensors",
+    "tokenizer*",
+    "spm.model",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "vocab*",
+    "merges.txt",
+]
 
 
 def _config_digest(path: Path) -> str | None:
@@ -65,24 +81,54 @@ class ModelStore:
         path = self.manifest_path(tier)
         if not path.is_file():
             return None
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return ModelManifest.model_validate(data)
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return ModelManifest.model_validate(data)
+        except (json.JSONDecodeError, ValidationError) as exc:
+            _log.warning(
+                "Ignoring corrupt manifest for tier %s at %s: %s",
+                tier,
+                path,
+                exc,
+            )
+            return None
 
     def write_manifest(self, manifest: ModelManifest) -> None:
         tier_dir = self.tier_dir(manifest.tier)
         tier_dir.mkdir(parents=True, exist_ok=True)
-        self.manifest_path(manifest.tier).write_text(
+        target = self.manifest_path(manifest.tier)
+        tmp = target.with_suffix(".json.tmp")
+        tmp.write_text(
             manifest.model_dump_json(indent=2),
             encoding="utf-8",
         )
+        os.replace(tmp, target)
 
-    def resolve_local_path(self, tier: str) -> Path | None:
-        """Return cached checkpoint dir if manifest + config.json exist and match catalog."""
+    def is_valid_checkpoint(self, path: Path) -> bool:
+        if not path.is_dir() or not (path / "config.json").is_file():
+            return False
+        return any((path / name).is_file() for name in _WEIGHT_FILES)
+
+    def _installed_checkpoint(self, tier: str) -> Path | None:
+        """Return cached checkpoint when manifest + weights exist (revision may be stale)."""
         manifest = self.read_manifest(tier)
         if manifest is None:
             return None
         ckpt = Path(manifest.path)
-        if not ckpt.is_dir() or not (ckpt / "config.json").is_file():
+        if not self.is_valid_checkpoint(ckpt):
+            return None
+        digest = _config_digest(ckpt)
+        if manifest.config_digest is not None and digest != manifest.config_digest:
+            return None
+        return ckpt
+
+    def resolve_local_path(self, tier: str) -> Path | None:
+        """Return cached checkpoint dir if manifest matches catalog revision."""
+        manifest = self.read_manifest(tier)
+        if manifest is None:
+            return None
+        ckpt = Path(manifest.path)
+        if not self.is_valid_checkpoint(ckpt):
             return None
 
         cat = load_catalog()
@@ -95,9 +141,6 @@ class ModelStore:
             return None
 
         return ckpt
-
-    def is_valid_checkpoint(self, path: Path) -> bool:
-        return path.is_dir() and (path / "config.json").is_file()
 
     def ensure_tier(
         self,
@@ -121,34 +164,49 @@ class ModelStore:
         from huggingface_hub import snapshot_download
 
         dest = self.tier_dir(tier) / "checkpoint"
-        if force and dest.exists():
-            shutil.rmtree(dest)
-        dest.mkdir(parents=True, exist_ok=True)
+        temp_dest = self.tier_dir(tier) / f".checkpoint-download-{os.getpid()}"
+        backup = self.tier_dir(tier) / ".checkpoint.bak"
 
-        local_dir = snapshot_download(
-            repo_id=tier_entry.repo_id,
-            revision=tier_entry.revision,
-            local_dir=str(dest),
-            local_dir_use_symlinks=False,
-        )
-        ckpt = Path(local_dir)
-        if not self.is_valid_checkpoint(ckpt):
-            msg = (
-                f"Downloaded model at {ckpt} is missing config.json. "
-                f"Check repo {tier_entry.repo_id!r} on Hugging Face."
+        if temp_dest.exists():
+            shutil.rmtree(temp_dest)
+        temp_dest.mkdir(parents=True, exist_ok=True)
+
+        try:
+            local_dir = snapshot_download(
+                repo_id=tier_entry.repo_id,
+                revision=tier_entry.revision,
+                local_dir=str(temp_dest),
+                allow_patterns=_SNAPSHOT_ALLOW_PATTERNS,
             )
-            raise ConfigError(msg)
+            ckpt = Path(local_dir)
+            if not self.is_valid_checkpoint(ckpt):
+                msg = (
+                    f"Downloaded model at {ckpt} is missing config.json or weight files. "
+                    f"Check repo {tier_entry.repo_id!r} on Hugging Face."
+                )
+                raise ConfigError(msg)
 
-        self.write_manifest(
-            ModelManifest(
+            manifest = ModelManifest(
                 tier=tier,
                 repo_id=tier_entry.repo_id,
                 revision=tier_entry.revision,
-                path=str(ckpt),
+                path=str(dest),
                 config_digest=_config_digest(ckpt),
             )
-        )
-        return ckpt
+
+            if backup.exists():
+                shutil.rmtree(backup)
+            if dest.exists():
+                os.replace(dest, backup)
+            os.replace(ckpt, dest)
+            self.write_manifest(manifest.model_copy(update={"path": str(dest)}))
+            if backup.exists():
+                shutil.rmtree(backup)
+            return dest
+        except Exception:
+            if temp_dest.exists():
+                shutil.rmtree(temp_dest)
+            raise
 
     def list_status(self) -> list[dict[str, Any]]:
         """Status for every catalog tier (installed / upgrade available)."""
@@ -157,20 +215,20 @@ class ModelStore:
         for tier_id in cat.tier_names():
             entry = cat.tiers[tier_id]
             manifest = self.read_manifest(tier_id)
-            local = self.resolve_local_path(tier_id)
+            installed_ckpt = self._installed_checkpoint(tier_id)
             rows.append(
                 {
                     "tier": tier_id,
                     "name": entry.name,
                     "repo_id": entry.repo_id,
                     "catalog_revision": entry.revision,
-                    "installed": local is not None,
+                    "installed": installed_ckpt is not None,
                     "installed_revision": manifest.revision if manifest else None,
-                    "path": str(local) if local else None,
+                    "path": str(installed_ckpt) if installed_ckpt else None,
                     "upgrade_available": (
                         manifest is not None
                         and manifest.revision != entry.revision
-                        and local is not None
+                        and installed_ckpt is not None
                     ),
                     "description": entry.description,
                 }
@@ -180,8 +238,15 @@ class ModelStore:
     def resolve_spec_path(self, spec: ModelSpec, tier: str | None = None) -> ModelSpec:
         """Fill spec.path from env override, explicit path, or cache."""
         env_path = os.environ.get("UNPLUG_MODEL_PATH")
-        if env_path and self.is_valid_checkpoint(Path(env_path)):
-            return spec.model_copy(update={"path": env_path})
+        if env_path:
+            env = Path(env_path)
+            if self.is_valid_checkpoint(env):
+                return spec.model_copy(update={"path": env_path})
+            _log.warning(
+                "UNPLUG_MODEL_PATH=%s is set but is not a valid checkpoint "
+                "(need config.json and model.safetensors or pytorch_model.bin); ignoring.",
+                env_path,
+            )
 
         if spec.path and self.is_valid_checkpoint(Path(spec.path)):
             return spec

--- a/sdk/src/unplug/ml/store.py
+++ b/sdk/src/unplug/ml/store.py
@@ -22,6 +22,8 @@ _log = get_logger("ml.store")
 
 _WEIGHT_FILES = ("model.safetensors", "pytorch_model.bin")
 
+# Downloads are safetensors-only by policy (no pickle .bin fetches); .bin
+# stays in _WEIGHT_FILES so pre-existing local checkpoints still validate.
 _SNAPSHOT_ALLOW_PATTERNS = [
     "*.json",
     "*.safetensors",
@@ -165,12 +167,13 @@ class ModelStore:
 
         dest = self.tier_dir(tier) / "checkpoint"
         temp_dest = self.tier_dir(tier) / f".checkpoint-download-{os.getpid()}"
-        backup = self.tier_dir(tier) / ".checkpoint.bak"
+        backup = self.tier_dir(tier) / f".checkpoint-{os.getpid()}.bak"
 
         if temp_dest.exists():
             shutil.rmtree(temp_dest)
         temp_dest.mkdir(parents=True, exist_ok=True)
 
+        moved_to_backup = False
         try:
             local_dir = snapshot_download(
                 repo_id=tier_entry.repo_id,
@@ -198,12 +201,19 @@ class ModelStore:
                 shutil.rmtree(backup)
             if dest.exists():
                 os.replace(dest, backup)
+                moved_to_backup = True
             os.replace(ckpt, dest)
-            self.write_manifest(manifest.model_copy(update={"path": str(dest)}))
+            self.write_manifest(manifest)
             if backup.exists():
                 shutil.rmtree(backup)
             return dest
         except Exception:
+            # Roll back to the last good checkpoint so a failed swap never
+            # strands the tier without a model (manifest still matches it).
+            if moved_to_backup and backup.exists():
+                if dest.exists():
+                    shutil.rmtree(dest)
+                os.replace(backup, dest)
             if temp_dest.exists():
                 shutil.rmtree(temp_dest)
             raise

--- a/sdk/tests/unit/cli/test_models_cli.py
+++ b/sdk/tests/unit/cli/test_models_cli.py
@@ -48,6 +48,8 @@ class _FakeStore:
             raise ModelError("bad model")
         if tier == "boom":
             raise RuntimeError("network")
+        if tier == "missing-import":
+            raise ImportError("No module named 'huggingface_hub'")
         return f"/models/{tier}"
 
 
@@ -111,16 +113,41 @@ def test_models_download_known_errors(
     assert "Error:" in capsys.readouterr().err
 
 
-def test_models_download_unexpected_error_mentions_ml_extra(
+def test_models_download_import_error_mentions_ml_extra(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setattr(models, "ModelStore", _FakeStore)
 
-    code = models._cmd_download(argparse.Namespace(tier="boom", force=False))
+    code = models._cmd_download(argparse.Namespace(tier="missing-import", force=False))
 
     assert code == 1
-    assert "pip install 'unplug-ai[ml]'" in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert "pip install 'unplug-ai[ml]'" in err
+
+
+def test_models_download_network_error_without_extras_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    hf_error = type(
+        "HfHubHTTPError",
+        (Exception,),
+        {"__module__": "huggingface_hub.errors"},
+    )
+
+    class _NetworkStore(_FakeStore):
+        def ensure_tier(self, tier: str, *, force: bool = False) -> str:
+            raise hf_error("404 Client Error for repo Unplug-AI/unplug-tiny-v1")
+
+    monkeypatch.setattr(models, "ModelStore", _NetworkStore)
+
+    code = models._cmd_download(argparse.Namespace(tier="tiny", force=False))
+
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "pip install 'unplug-ai[ml]'" not in err
+    assert "Hugging Face" in err
 
 
 def test_models_status(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:

--- a/sdk/tests/unit/core/test_model_runtime.py
+++ b/sdk/tests/unit/core/test_model_runtime.py
@@ -1,0 +1,69 @@
+"""Tests for Guard ML init and model runtime resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from unplug.config.guard import GuardConfig
+from unplug.core.runtime.model_runtime import merge_catalog_models
+from unplug.exceptions import ConfigError, ModelError
+
+
+def test_guard_degrades_when_download_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.delenv("UNPLUG_MODEL_PATH", raising=False)
+    monkeypatch.setenv("UNPLUG_MODEL_CACHE", str(tmp_path / "cache"))
+
+    def boom(self: object, tier: str, **kwargs: object) -> Path:
+        msg = "offline"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("unplug.ml.store.ModelStore.ensure_tier", boom)
+
+    from unplug import Guard
+
+    with caplog.at_level("WARNING", logger="unplug.guard"):
+        guard = Guard(
+            config=merge_catalog_models(
+                GuardConfig(active_model="tiny", auto_download_model=True, require_ml=False)
+            )
+        )
+    assert guard.ml_degraded is True
+    assert guard.ml_model_loaded is False
+    assert "pip install" in caplog.text
+    assert "unplug-models download tiny" in caplog.text
+
+
+def test_guard_require_ml_raises_when_download_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("UNPLUG_MODEL_PATH", raising=False)
+    monkeypatch.setenv("UNPLUG_MODEL_CACHE", str(tmp_path / "cache"))
+
+    def boom(self: object, tier: str, **kwargs: object) -> Path:
+        msg = "offline"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr("unplug.ml.store.ModelStore.ensure_tier", boom)
+
+    from unplug import Guard
+
+    with pytest.raises(ModelError, match="require_ml"):
+        Guard(
+            config=merge_catalog_models(
+                GuardConfig(active_model="tiny", auto_download_model=True, require_ml=True)
+            )
+        )
+
+
+def test_guard_unknown_active_model_raises_config_error() -> None:
+    from unplug import Guard
+
+    with pytest.raises(ConfigError, match="Valid tiers"):
+        Guard(config=GuardConfig(active_model="typo", require_ml=True))

--- a/sdk/tests/unit/ml/test_model_store.py
+++ b/sdk/tests/unit/ml/test_model_store.py
@@ -2,15 +2,29 @@
 
 from __future__ import annotations
 
+import logging
+import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 from unplug.config.guard import GuardConfig
-from unplug.core.runtime.model_runtime import merge_catalog_models
-from unplug.exceptions import ModelError
+from unplug.core.runtime.model_runtime import merge_catalog_models, resolve_active_model_spec
+from unplug.exceptions import ConfigError, ModelError
 from unplug.ml.catalog import load_catalog
-from unplug.ml.store import ModelStore
+from unplug.ml.store import ModelManifest, ModelStore, _config_digest
+
+
+def _write_checkpoint(
+    ckpt: Path,
+    *,
+    config: str = "{}",
+    weights: bytes = b"x" * 10,
+) -> None:
+    ckpt.mkdir(parents=True, exist_ok=True)
+    (ckpt / "config.json").write_text(config, encoding="utf-8")
+    (ckpt / "model.safetensors").write_bytes(weights)
 
 
 def test_catalog_loads_tiny_tier() -> None:
@@ -29,12 +43,9 @@ def test_merge_catalog_injects_tiers() -> None:
 def test_store_manifest_roundtrip(tmp_path: Path) -> None:
     store = ModelStore(cache_root=tmp_path)
     ckpt = tmp_path / "tiny" / "checkpoint"
-    ckpt.mkdir(parents=True)
-    (ckpt / "config.json").write_text("{}", encoding="utf-8")
+    _write_checkpoint(ckpt)
     manifest = store.read_manifest("tiny")
     assert manifest is None
-    from unplug.ml.store import ModelManifest
-
     store.write_manifest(
         ModelManifest(
             tier="tiny",
@@ -51,10 +62,7 @@ def test_store_manifest_roundtrip(tmp_path: Path) -> None:
 def test_store_rejects_stale_catalog_revision(tmp_path: Path) -> None:
     store = ModelStore(cache_root=tmp_path)
     ckpt = tmp_path / "tiny" / "checkpoint"
-    ckpt.mkdir(parents=True)
-    (ckpt / "config.json").write_text("{}", encoding="utf-8")
-    from unplug.ml.store import ModelManifest
-
+    _write_checkpoint(ckpt)
     store.write_manifest(
         ModelManifest(
             tier="tiny",
@@ -69,10 +77,7 @@ def test_store_rejects_stale_catalog_revision(tmp_path: Path) -> None:
 def test_store_accepts_matching_revision_and_digest(tmp_path: Path) -> None:
     store = ModelStore(cache_root=tmp_path)
     ckpt = tmp_path / "tiny" / "checkpoint"
-    ckpt.mkdir(parents=True)
-    (ckpt / "config.json").write_text('{"model": "test"}', encoding="utf-8")
-    from unplug.ml.store import ModelManifest, _config_digest
-
+    _write_checkpoint(ckpt, config='{"model": "test"}')
     digest = _config_digest(ckpt)
     store.write_manifest(
         ModelManifest(
@@ -88,8 +93,7 @@ def test_store_accepts_matching_revision_and_digest(tmp_path: Path) -> None:
 
 def test_env_path_overrides_cache(tmp_path: Path, monkeypatch) -> None:
     ckpt = tmp_path / "env_ckpt"
-    ckpt.mkdir()
-    (ckpt / "config.json").write_text("{}", encoding="utf-8")
+    _write_checkpoint(ckpt)
     monkeypatch.setenv("UNPLUG_MODEL_PATH", str(ckpt))
     store = ModelStore(cache_root=tmp_path / "cache")
     spec = load_catalog().tiers["tiny"].to_model_spec()
@@ -141,7 +145,8 @@ def test_guard_survives_corrupt_checkpoint(tmp_path: Path, monkeypatch: pytest.M
 
 
 def test_guard_require_ml_corrupt_checkpoint_raises_model_error(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     pytest.importorskip("torch")
     monkeypatch.delenv("UNPLUG_MODEL_PATH", raising=False)
@@ -159,3 +164,135 @@ def test_guard_require_ml_corrupt_checkpoint_raises_model_error(
 
     with pytest.raises(ModelError, match="require_ml"):
         Guard(config=cfg)
+
+
+def test_corrupt_manifest_returns_none_and_list_status_ok(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = ModelStore(cache_root=tmp_path)
+    manifest_path = store.manifest_path("tiny")
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text("{truncated", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger="unplug.ml.store"):
+        assert store.read_manifest("tiny") is None
+        assert store.resolve_local_path("tiny") is None
+        rows = store.list_status()
+    assert rows[0]["tier"] == "tiny"
+    assert rows[0]["installed"] is False
+    assert "corrupt manifest" in caplog.text.lower()
+
+
+def test_unknown_active_model_raises_config_error() -> None:
+    cfg = merge_catalog_models(GuardConfig(active_model="typo"))
+    with pytest.raises(ConfigError, match="Valid tiers"):
+        resolve_active_model_spec(cfg)
+
+
+def test_ensure_tier_redownloads_when_weights_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ModelStore(cache_root=tmp_path)
+    ckpt = tmp_path / "tiny" / "checkpoint"
+    ckpt.mkdir(parents=True)
+    (ckpt / "config.json").write_text("{}", encoding="utf-8")
+    store.write_manifest(
+        ModelManifest(
+            tier="tiny",
+            repo_id="Unplug-AI/test",
+            revision=load_catalog().tiers["tiny"].revision,
+            path=str(ckpt),
+        )
+    )
+    assert store.resolve_local_path("tiny") is None
+
+    def fake_snapshot_download(**kwargs: object) -> str:
+        local_dir = Path(str(kwargs["local_dir"]))
+        _write_checkpoint(local_dir)
+        return str(local_dir)
+
+    hf = ModuleType("huggingface_hub")
+    hf.snapshot_download = fake_snapshot_download  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hf)
+    monkeypatch.setattr(
+        "unplug.ml.store.require_huggingface_hub",
+        lambda: None,
+    )
+
+    resolved = store.ensure_tier("tiny")
+    assert resolved == ckpt
+    assert store.is_valid_checkpoint(resolved)
+
+
+def test_stale_revision_reports_installed_and_upgrade_available(tmp_path: Path) -> None:
+    store = ModelStore(cache_root=tmp_path)
+    ckpt = tmp_path / "tiny" / "checkpoint"
+    _write_checkpoint(ckpt)
+    store.write_manifest(
+        ModelManifest(
+            tier="tiny",
+            repo_id="Unplug-AI/test",
+            revision="stale-revision",
+            path=str(ckpt),
+        )
+    )
+    row = next(r for r in store.list_status() if r["tier"] == "tiny")
+    assert row["installed"] is True
+    assert row["upgrade_available"] is True
+    assert store.resolve_local_path("tiny") is None
+
+
+def test_force_download_failure_preserves_old_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ModelStore(cache_root=tmp_path)
+    ckpt = tmp_path / "tiny" / "checkpoint"
+    _write_checkpoint(ckpt, config='{"model": "keep"}')
+    digest = _config_digest(ckpt)
+    store.write_manifest(
+        ModelManifest(
+            tier="tiny",
+            repo_id="Unplug-AI/test",
+            revision=load_catalog().tiers["tiny"].revision,
+            path=str(ckpt),
+            config_digest=digest,
+        )
+    )
+
+    def boom(**kwargs: object) -> str:
+        msg = "network down"
+        raise RuntimeError(msg)
+
+    hf = ModuleType("huggingface_hub")
+    hf.snapshot_download = boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hf)
+    monkeypatch.setattr(
+        "unplug.ml.store.require_huggingface_hub",
+        lambda: None,
+    )
+
+    with pytest.raises(RuntimeError, match="network down"):
+        store.ensure_tier("tiny", force=True)
+
+    assert store.resolve_local_path("tiny") == ckpt
+
+
+def test_invalid_unplug_model_path_logs_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    bad = tmp_path / "bad_ckpt"
+    bad.mkdir()
+    (bad / "config.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("UNPLUG_MODEL_PATH", str(bad))
+    store = ModelStore(cache_root=tmp_path / "cache")
+    spec = load_catalog().tiers["tiny"].to_model_spec()
+    with caplog.at_level(logging.WARNING, logger="unplug.ml.store"):
+        resolved = store.resolve_spec_path(spec, tier="tiny")
+    assert resolved.path is None
+    assert "UNPLUG_MODEL_PATH" in caplog.text
+    assert str(bad) in caplog.text

--- a/sdk/tests/unit/ml/test_model_store.py
+++ b/sdk/tests/unit/ml/test_model_store.py
@@ -280,6 +280,54 @@ def test_force_download_failure_preserves_old_checkpoint(
     assert store.resolve_local_path("tiny") == ckpt
 
 
+def test_failed_swap_restores_backup_checkpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Failure after the old checkpoint moved to backup must roll it back."""
+    store = ModelStore(cache_root=tmp_path)
+    ckpt = tmp_path / "tiny" / "checkpoint"
+    _write_checkpoint(ckpt, config='{"model": "keep"}')
+    digest = _config_digest(ckpt)
+    store.write_manifest(
+        ModelManifest(
+            tier="tiny",
+            repo_id="Unplug-AI/test",
+            revision=load_catalog().tiers["tiny"].revision,
+            path=str(ckpt),
+            config_digest=digest,
+        )
+    )
+
+    def fake_snapshot_download(**kwargs: object) -> str:
+        local_dir = Path(str(kwargs["local_dir"]))
+        _write_checkpoint(local_dir, config='{"model": "new"}')
+        return str(local_dir)
+
+    hf = ModuleType("huggingface_hub")
+    hf.snapshot_download = fake_snapshot_download  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hf)
+    monkeypatch.setattr(
+        "unplug.ml.store.require_huggingface_hub",
+        lambda: None,
+    )
+
+    def broken_write(manifest: ModelManifest) -> None:
+        msg = "disk full"
+        raise OSError(msg)
+
+    monkeypatch.setattr(store, "write_manifest", broken_write)
+
+    with pytest.raises(OSError, match="disk full"):
+        store.ensure_tier("tiny", force=True)
+
+    # Old checkpoint restored at the original path; manifest still matches it.
+    assert (ckpt / "config.json").read_text(encoding="utf-8") == '{"model": "keep"}'
+    assert store.resolve_local_path("tiny") == ckpt
+    leftovers = [p.name for p in (tmp_path / "tiny").iterdir() if p.name != "checkpoint"]
+    assert leftovers == ["manifest.json"]
+
+
 def test_invalid_unplug_model_path_logs_warning(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Move ML spec resolution/download inside Guard's degradation try/except so download failures honor `require_ml` and avoid double resolve
- Harden `ModelStore`: corrupt manifest handling, weight-file validation, atomic manifest writes and download swaps, fixed `list_status` stale-revision reporting, `UNPLUG_MODEL_PATH` warnings, filtered HF snapshot downloads
- Raise `ConfigError` for unknown `active_model` tiers; improve `unplug-models download` error messages (ImportError vs hub/network)

## Test plan
- [x] `make check` (ruff, mypy, pytest)
- [x] `make test-cov` (82.08% total, gate 80%)
- [x] Regression tests for all audit findings (F1, F3, F4, F5, F6, F9, F11, F12, F14)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect ML loading, cache upgrades, and config validation at Guard init; behavior is stricter (unknown tiers fail fast) but failures are more recoverable during downloads.
> 
> **Overview**
> **Hardens the local ML model cache and tightens how Guard loads `active_model`.**
> 
> `ModelStore` now tolerates corrupt manifests (warn + treat as missing), requires weight files for a valid checkpoint, writes manifests atomically, and downloads into a temp dir with backup/rollback so failed upgrades do not remove a working install. `list_status` treats stale catalog revisions as still **installed** while flagging **upgrade available**; invalid `UNPLUG_MODEL_PATH` is logged and ignored. Hugging Face snapshots are limited to safetensors/tokenizer patterns.
> 
> Unknown `active_model` tier names raise **`ConfigError`** with the valid catalog list instead of silently skipping ML. Guard resolves and downloads the model in one try/except path (reusing the resolved spec for the provider), propagates `ConfigError`, and respects **`require_ml`** on download/load failures. `unplug-models download` separates **`ImportError`** (install `[ml]`) from hub/network errors with a HF hint.
> 
> Regression tests cover manifest corruption, missing weights, stale revision reporting, download rollback, env path warnings, CLI errors, and Guard degradation vs `require_ml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25580e24e683746f729e31a9ef92fd35227a7978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->