### PR TITLE
Agent usability: docs, imports, REVIEW log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the `unplug-ai` SDK.
 
 ### Fixed
 
+- Agent usability: `Guard.init()` docstring no longer claims auto-instrumentation; docs standardize on `from unplug import ...` for apps and `unplug.api.*` for server/MCP dependents; routine `REVIEW` pipeline outcomes log at INFO instead of WARNING
 - ML inference hardening: BIOES decode no longer crashes on checkpoints without `*-INJ` labels; label maps are validated at load with a clear `ModelError`; forced torch devices are validated (`ConfigError`); `ModelProvider`/`SpanInferenceModel` load is thread-safe; ML modules log device/tokenizer fallbacks and import torch via `unplug.optional.ml` helpers
 - Model store hardening: corrupt manifests no longer crash Guard or `unplug-models`; checkpoint validation requires weight files; atomic manifest writes and download swaps preserve existing installs on failure; `list_status` correctly reports stale revisions as upgrade-available; invalid `UNPLUG_MODEL_PATH` logs a warning; CLI download errors distinguish missing ML extras from network/repo failures
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ uv sync && uv pip install -e ".[ml]"
 
 ## Quickstart
 
+App and agent code imports from the top-level package (`from unplug import Guard`).
+Server/MCP integrations use `unplug.api.*` for wire types and facades — see
+[`sdk/docs/PUBLIC_API.md`](sdk/docs/PUBLIC_API.md). Do not use `unplug.core.*`.
+
 ```python
 from unplug import Guard
 from unplug.api.enums import Source

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -30,6 +30,10 @@ pip install unplug-ai           # regex-only core, zero ML deps
 pip install "unplug-ai[ml]"     # add the ML span model
 ```
 
+**Imports:** App and agent code uses `from unplug import Guard` (and other top-level
+exports). Server/MCP dependents that need wire types or facades use `unplug.api.*`
+— see [`docs/PUBLIC_API.md`](docs/PUBLIC_API.md). Do not import from `unplug.core.*`.
+
 Or from source:
 
 ```bash

--- a/sdk/docs/AGENT_ACTIONS.md
+++ b/sdk/docs/AGENT_ACTIONS.md
@@ -2,6 +2,9 @@
 
 Every Unplug scan returns an **`Action`**. Agent hosts and integration adapters must handle each action differently — especially **`REVIEW`**, which is not the same as **`BLOCK`**.
 
+Examples below use `from unplug import Guard` for the host and `from unplug.api.*` only
+where wire types or enums are needed. Do not import from `unplug.core.*`.
+
 ## Decision table
 
 | `result.action` | `result.safe` | `HookDecision.allowed` | Agent host should |

--- a/sdk/docs/GETTING_STARTED.md
+++ b/sdk/docs/GETTING_STARTED.md
@@ -14,6 +14,10 @@ Package name on PyPI is **`unplug-ai`**. You import it as **`unplug`**:
 from unplug import Guard
 ```
 
+**Import style:** Apps and agents use top-level `unplug` exports. Server/MCP code
+that needs policy, cache, or boundary facades uses `unplug.api.*`
+([`PUBLIC_API.md`](PUBLIC_API.md)). Avoid `unplug.core.*` — it is internal.
+
 Optional ML model (better recall on indirect injection):
 
 ```bash

--- a/sdk/docs/PUBLIC_API.md
+++ b/sdk/docs/PUBLIC_API.md
@@ -1,5 +1,13 @@
 # Public SDK API Surface
 
+## Which import path?
+
+| Audience | Import from | Example |
+|----------|-------------|---------|
+| **App and agent authors** | Top-level `unplug` exports | `from unplug import Guard` |
+| **Server, MCP, and dependents** needing policy, cache, boundaries, or ML facades | `unplug.api.*` | `from unplug.api.types import ScanRequest` |
+| **Do not use in new code** | `unplug.core.*` | Internal; may change in minor releases |
+
 Use `unplug.api.*` for cross-repository integrations. Treat `unplug.core.*` and
 most of `unplug.ml.*` as private implementation details that can move during SDK
 refactors.

--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -702,7 +702,7 @@ class Guard:
 
     @classmethod
     def init(cls, **kwargs: Any) -> Guard:
-        """Initialize a global Guard and auto-instrument detected frameworks."""
+        """Create and store a process-wide Guard singleton (see ``get()``)."""
         with cls._lock:
             cls._instance = Guard(**kwargs)
             return cls._instance

--- a/sdk/src/unplug/pipelines/base.py
+++ b/sdk/src/unplug/pipelines/base.py
@@ -114,7 +114,10 @@ class BasePipeline(ABC):
 
         ctx.update_risk(risk_score)
 
-        log_fn = _log.warning if 0.3 <= risk_score < 0.5 else _log.info
+        if action == Action.REVIEW:
+            log_fn = _log.info
+        else:
+            log_fn = _log.warning if 0.3 <= risk_score < 0.5 else _log.info
         log_fn(
             "pipeline %s: action=%s risk=%.2f findings=%d latency=%.1fms",
             self.name,

--- a/sdk/tests/unit/pipelines/test_pipelines.py
+++ b/sdk/tests/unit/pipelines/test_pipelines.py
@@ -1,8 +1,13 @@
 """Tests for pipelines: input, output, tool call."""
 
+import logging
+
+import pytest
+
 from unplug.core.context import ExecutionContext, ToolCall
 from unplug.core.privacy.secrets import SecretsRegistry, SecretsSanitizer
 from unplug.core.taint import TaintedText, TrustLevel
+from unplug.guard import Guard
 from unplug.models import Action, Source
 from unplug.pipelines.input import InputPipeline
 from unplug.pipelines.output import OutputPipeline
@@ -226,3 +231,23 @@ class TestToolCallPipeline:
         result = pipeline.run(tc)
         assert not result.safe
         assert any(f.category == "destructive" for f in result.findings)
+
+
+class TestPipelineLogging:
+    def test_review_outcome_logs_at_info(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        guard = Guard()
+        guard.scan("Poisoned doc", source=Source.RETRIEVED)
+        with caplog.at_level(logging.DEBUG, logger="unplug.pipelines"):
+            result = guard.check_tool_call("shell", {"command": "echo hello"})
+        assert result.action == Action.REVIEW
+        review_records = [
+            record
+            for record in caplog.records
+            if record.name == "unplug.pipelines" and "action=review" in record.getMessage()
+        ]
+        assert review_records
+        assert all(record.levelno == logging.INFO for record in review_records)
+        assert not any(record.levelno == logging.WARNING for record in review_records)


### PR DESCRIPTION
## Summary

- Fix `Guard.init()` docstring — it described auto-instrumentation that does not exist; now documents the process-wide singleton.
- Standardize import guidance across primary docs: apps/agents use `from unplug import ...`; server/MCP dependents use `unplug.api.*`; `unplug.core.*` is internal.
- Downgrade routine `REVIEW` pipeline outcome logs from WARNING to INFO (scanner errors / ML degradation warnings unchanged).
- ML degradation warnings in `guard.py` were already unified in #72 — both load-failure paths cite `pip install "unplug-ai[ml]"` plus `unplug-models download`; no code change needed.

## Changed files

| Item | Files |
|------|-------|
| 1. `Guard.init()` docstring | `sdk/src/unplug/guard.py` |
| 2. Import-style docs | `README.md`, `sdk/README.md`, `sdk/docs/GETTING_STARTED.md`, `sdk/docs/PUBLIC_API.md`, `sdk/docs/AGENT_ACTIONS.md` |
| 3. REVIEW log level | `sdk/src/unplug/pipelines/base.py`, `sdk/tests/unit/pipelines/test_pipelines.py` |
| 4. Degradation warnings | Already done (#72) — verified only |

## Test plan

- [x] `make check` (ruff, mypy, pytest)
- [x] `make test-cov` — **85.59%** total coverage (80% gate)
- [x] New `TestPipelineLogging.test_review_outcome_logs_at_info` asserts REVIEW logs at INFO via caplog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and logging-only changes; no scan policy, auth, or enforcement behavior changes beyond log level for REVIEW.
> 
> **Overview**
> **Agent usability** polish: correct `Guard.init()` docs, standardize import guidance, and quiet routine **REVIEW** pipeline logs.
> 
> `Guard.init()` no longer claims auto-instrumentation; the docstring now describes creating the process-wide singleton used with `Guard.get()`.
> 
> Primary docs (**README**, **GETTING_STARTED**, **PUBLIC_API**, **AGENT_ACTIONS**) now spell out import paths: apps/agents use top-level `from unplug import ...`; server/MCP dependents use `unplug.api.*`; `unplug.core.*` is internal.
> 
> In **`BasePipeline`**, normal **`REVIEW`** outcomes log at **INFO** instead of **WARNING** (mid-risk scores no longer elevate REVIEW to warning). Scanner errors and other degradation warnings are unchanged.
> 
> Adds **`TestPipelineLogging.test_review_outcome_logs_at_info`** and a **CHANGELOG** entry under Fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7fc6dcfccbfe083750ae997166a3bbb1790ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->