### PR TITLE
Polish packaging extras and install docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Install
         run: |
           if [ "${{ matrix.python-version }}" = "3.13" ]; then
-            # tokenizers 0.19 (pulled by ml/litellm) has no cp313 wheels yet — skip those extras.
-            uv sync --extra dev --extra scrape --extra yara --extra haystack --extra presidio --group dev
+            # Skip ml/litellm on the 3.13 test matrix (heavy); wheel-only resolve
+            # for [ml] is covered by the packaging-ml-wheels job below.
+            uv sync --extra scrape --extra yara --extra haystack --extra presidio --dev
           else
             uv sync --all-extras --dev
           fi
@@ -72,3 +73,25 @@ jobs:
           xml-skip-covered: true
           report-only-changed-files: true
           default-branch: dev
+
+  # Catch sdist-only transitive breakage that plain lock/compile misses
+  # (e.g. tokenizers without a cp313 wheel). Dry-run — no torch download.
+  packaging-ml-wheels:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          version: "0.6.14"
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+
+      - name: Resolve unplug-ai[ml] wheels-only
+        run: uv pip compile --python-version 3.13 --extra ml --no-build -o /tmp/ml-wheels.txt pyproject.toml

--- a/.github/workflows/integrations-live.yml
+++ b/.github/workflows/integrations-live.yml
@@ -87,7 +87,8 @@ jobs:
         # resolves that one framework freshly. We mirror that here.
         run: |
           uv venv
-          uv pip install -e ".[dev,${{ matrix.extra }}]"
+          # Framework extra freshly resolved; pytest via dependency-group (not a PyPI extra).
+          uv pip install -e ".[${{ matrix.extra }}]" --group dev
 
       - name: Live integration test
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ All notable changes to the `unplug-ai` SDK.
 ### Added
 
 - Offline synthetic BIOES checkpoint fixture for ML unit tests (no real weights required)
+- CI wheel-only resolve for `unplug-ai[ml]` on Python 3.13 (catches sdist-only breakage)
 
 ### Changed
 
 - Unknown `active_model` tier names now raise `ConfigError` with valid catalog tiers instead of silently running without ML
+- Widen `transformers` extra constraint to `>=4.44,<6` (was `<5.13`) so newer minors stay installable
+- Drop published `dev` optional-extra; test/lint tools live in the `dev` dependency-group (`uv sync --dev`)
+- Docs: `unplug-ai[scrape]` package name in Firecrawl docstring; Atomic Agents Python ≥3.12 install gate; Semantic Kernel `pybars4` wheel-only note
 
 ### Fixed
 

--- a/sdk/integrations/TESTING.md
+++ b/sdk/integrations/TESTING.md
@@ -115,19 +115,21 @@ These run in the dedicated **`Integrations (live)`** workflow
 nightly (06:00 UTC), and via manual dispatch — keeping the everyday PR gate fast while
 still catching framework drift.
 
-**Fresh resolution, on purpose.** Each leg runs `uv pip install -e ".[dev,<extra>]"`, *not*
-`uv sync`. The unified `uv.lock` co-resolves every extra together and pins some frameworks to
-old releases (e.g. `semantic-kernel` 1.15, which imports `Url` from `pydantic.networks` —
-removed in Pydantic v2). No user installs every framework at once; they run
+**Fresh resolution, on purpose.** Each leg runs
+`uv pip install -e ".[<extra>]" --group dev`, *not* `uv sync`. The unified `uv.lock`
+co-resolves every extra together and pins some frameworks to old releases
+(e.g. `semantic-kernel` 1.15, which imports `Url` from `pydantic.networks` — removed in
+Pydantic v2). No user installs every framework at once; they run
 `pip install "unplug-ai[semantic-kernel]"`, which resolves that one framework freshly (→ 1.36,
 which works). We mirror the user path. The `-e` (editable) keeps the source tree on `sys.path`
-so test-only assets like `configs/ml_validation.json` resolve.
+so test-only assets like `configs/ml_validation.json` resolve. `--group dev` pulls pytest
+from the dependency-group (not a published PyPI extra).
 
 Run one framework locally the same way CI does (latest compatible version of that extra):
 
 ```bash
 cd sdk
-uv venv --allow-existing /tmp/unplug-lg && uv pip install --python /tmp/unplug-lg -e ".[dev,langgraph]"
+uv venv --allow-existing /tmp/unplug-lg && uv pip install --python /tmp/unplug-lg -e ".[langgraph]" --group dev
 /tmp/unplug-lg/bin/python -m pytest -q -m requires_integrations tests/optional/live/test_langgraph_live.py
 ```
 

--- a/sdk/integrations/atomic-agents/README.md
+++ b/sdk/integrations/atomic-agents/README.md
@@ -12,7 +12,9 @@ Pydantic-schema-driven framework: `AtomicAgent[InputSchema, OutputSchema]` with
 - **Output** — scan the output schema's text field after `agent.run`.
 - **Tools** — gate a `BaseTool` call before it executes.
 
-> Atomic Agents 2.x requires Python ≥3.12, so this extra is a no-op on 3.11.
+> **Python ≥3.12 required.** The `atomic-agents` extra is gated with an environment
+> marker, so `pip install "unplug-ai[atomic-agents]"` on Python 3.11 installs nothing
+> (the package itself requires ≥3.12).
 
 ## Guard agent I/O
 

--- a/sdk/integrations/semantic-kernel/README.md
+++ b/sdk/integrations/semantic-kernel/README.md
@@ -3,6 +3,10 @@
 **Extra:** `pip install "unplug-ai[semantic-kernel]"`  
 **Module:** `unplug.integrations.semantic_kernel`
 
+> **Wheel-only installs:** `semantic-kernel` depends on `pybars4`, which publishes
+> sdists only on PyPI. `pip install --only-binary=:all:` / `uv --no-build` of
+> `unplug-ai[semantic-kernel]` or `[integrations]` will fail until a wheel exists.
+
 ## Filters around kernel invoke
 
 ```python

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 ml = [
     "huggingface_hub>=0.23",
     "onnxruntime>=1.17",
-    "transformers>=4.44,<5.13",
+    "transformers>=4.44,<6",
     "sentencepiece>=0.2",
     "numpy>=1.26",
     "torch>=2.0",
@@ -116,12 +116,6 @@ integrations = [
 # unrelated dependency trees. Live framework coverage runs in the dedicated
 # `integrations-live` CI job (see integrations/TESTING.md).
 all = ["unplug-ai[ml,scrape,litellm,yara,haystack,presidio]"]
-dev = [
-    "pytest>=8.0",
-    "pytest-asyncio>=0.23",
-    "pytest-cov>=7.1.0",
-    "ruff>=0.4",
-]
 
 [project.urls]
 Homepage = "https://unplug-ai.org"
@@ -272,6 +266,10 @@ dev = [
     "datasets>=4.8.5",
     "mypy>=2.1.0",
     "pyarrow>=24.0.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pytest-cov>=7.1.0",
     "pyyaml>=6.0.3",
+    "ruff>=0.4",
     "types-pyyaml>=6.0.12.20260518",
 ]

--- a/sdk/src/unplug/providers/content/firecrawl.py
+++ b/sdk/src/unplug/providers/content/firecrawl.py
@@ -1,4 +1,4 @@
-"""Firecrawl-backed scraper (optional unplug[scrape] extra)."""
+"""Firecrawl-backed scraper (optional unplug-ai[scrape] extra)."""
 
 from __future__ import annotations
 

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -6949,12 +6949,6 @@ autogen = [
 crewai = [
     { name = "crewai" },
 ]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-]
 dspy = [
     { name = "dspy" },
 ]
@@ -7046,7 +7040,11 @@ dev = [
     { name = "datasets" },
     { name = "mypy" },
     { name = "pyarrow" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pyyaml" },
+    { name = "ruff" },
     { name = "types-pyyaml" },
 ]
 
@@ -7077,30 +7075,30 @@ requires-dist = [
     { name = "presidio-analyzer", marker = "extra == 'presidio'", specifier = ">=2.2" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-ai", marker = "extra == 'pydantic-ai'", specifier = ">=0.0.14" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "python-dotenv", marker = "extra == 'scrape'", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "semantic-kernel", marker = "extra == 'semantic-kernel'", specifier = ">=1.0" },
     { name = "sentencepiece", marker = "extra == 'ml'", specifier = ">=0.2" },
     { name = "smolagents", marker = "extra == 'smolagents'", specifier = ">=1.0" },
     { name = "strands-agents", marker = "extra == 'strands'", specifier = ">=1.0" },
     { name = "torch", marker = "extra == 'ml'", specifier = ">=2.0" },
-    { name = "transformers", marker = "extra == 'ml'", specifier = ">=4.44,<5.13" },
+    { name = "transformers", marker = "extra == 'ml'", specifier = ">=4.44,<6" },
     { name = "unplug-ai", extras = ["langgraph", "agno", "crewai", "autogen", "llama-index", "pydantic-ai", "semantic-kernel", "openai-agents", "langchain", "google-adk", "smolagents", "dspy", "strands", "letta", "griptape", "ag2", "atomic-agents", "haystack", "mcp"], marker = "extra == 'integrations'" },
     { name = "unplug-ai", extras = ["ml", "scrape", "litellm", "yara", "haystack", "presidio"], marker = "extra == 'all'" },
     { name = "yara-python", marker = "extra == 'yara'", specifier = ">=4.5" },
 ]
-provides-extras = ["ml", "litellm", "yara", "scrape", "haystack", "presidio", "langgraph", "agno", "crewai", "autogen", "llama-index", "pydantic-ai", "semantic-kernel", "openai-agents", "langchain", "google-adk", "smolagents", "dspy", "strands", "letta", "griptape", "ag2", "atomic-agents", "mcp", "integrations", "all", "dev"]
+provides-extras = ["ml", "litellm", "yara", "scrape", "haystack", "presidio", "langgraph", "agno", "crewai", "autogen", "llama-index", "pydantic-ai", "semantic-kernel", "openai-agents", "langchain", "google-adk", "smolagents", "dspy", "strands", "letta", "griptape", "ag2", "atomic-agents", "mcp", "integrations", "all"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "datasets", specifier = ">=4.8.5" },
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pyarrow", specifier = ">=24.0.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "ruff", specifier = ">=0.4" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
 


### PR DESCRIPTION
## Summary
- Fix wrong PyPI package name in Firecrawl docstring (`unplug-ai[scrape]`); widen `transformers` to `>=4.44,<6`
- Drop published `dev` optional-extra (pytest/ruff moved into the `dev` dependency-group for `uv sync --dev`)
- Document Atomic Agents Python ≥3.12 install gate and Semantic Kernel `pybars4` wheel-only constraint
- Add CI `packaging-ml-wheels` job: wheels-only resolve of `unplug-ai[ml]` on Python 3.13

## Test plan
- [x] `make check` (1113 passed)
- [x] `make test-cov` (85%+, gate met)
- [x] `uv pip compile --python-version 3.13 --extra ml --no-build` succeeds locally
- [ ] CI green on this PR (incl. new `packaging-ml-wheels` job)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are packaging, CI, and documentation; widening `transformers` is the only user-facing dependency shift and is low risk for typical installs.
> 
> **Overview**
> **Packaging and install ergonomics:** pytest/ruff are removed from the published `dev` optional-extra and moved into the uv **`dev` dependency-group** (`uv sync --dev`). The **`transformers`** constraint for `[ml]` is widened to **`>=4.44,<6`**. Firecrawl’s module docstring now says **`unplug-ai[scrape]`**.
> 
> **CI:** On Python **3.13**, the main SDK job skips **`ml`/`litellm`** during `uv sync` (lighter matrix) and uses **`--dev`** instead of **`--extra dev`**. A new **`packaging-ml-wheels`** job runs **`uv pip compile --extra ml --no-build`** on 3.13 to catch wheel-only / sdist breakage without downloading torch. **Integrations (live)** installs **`".[<extra>]" --group dev`** so pytest comes from the group, matching the dropped PyPI `dev` extra.
> 
> **Docs:** Atomic Agents README documents the **Python ≥3.12** extra marker; Semantic Kernel README notes **`pybars4`** sdist-only installs fail under **`--no-build`**. `integrations/TESTING.md` and **CHANGELOG** are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f826ce4b833a8cbc42b19da9b7525a57edfd4d5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->