### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the `unplug-ai` SDK.
 
 ## [Unreleased]
 
+## [0.5.2] — 2026-07-20
+
 ### Added
 
 - Coverage tests for v1.0 deprecation shim re-exports (`unplug.core.*`, `guard_scan`, `scanner`, `safeguards`)

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unplug-ai"
-version = "0.5.1"
+version = "0.5.2"
 description = "Unplug the bad AI. Fast prompt injection detection and redaction for LLM apps, agents, and RAG pipelines."
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/unplug/__init__.py
+++ b/sdk/src/unplug/__init__.py
@@ -73,7 +73,7 @@ try:
     # Single source of truth is pyproject.toml; avoids version drift.
     __version__ = _pkg_version("unplug-ai")
 except PackageNotFoundError:  # not installed (e.g. running from a source checkout)
-    __version__ = "0.5.1"
+    __version__ = "0.5.2"
 
 
 def __getattr__(name: str) -> object:

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -6910,7 +6910,7 @@ wheels = [
 
 [[package]]
 name = "unplug-ai"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Cuts **unplug-ai 0.5.2** (patch from 0.5.1). Shipping content is already on `dev` (#72–#77).

- `version` 0.5.1 → 0.5.2 (`pyproject.toml`, `__init__.py` fallback, `uv.lock`)
- CHANGELOG `[Unreleased]` → `[0.5.2] — 2026-07-20`

### What's in 0.5.2 (since 0.5.1)
- **Fixed:** Model store + Guard ML init hardening (#72); ML inference load/decode hardening (#73); agent usability docs/imports/REVIEW log level (#74)
- **Changed:** Packaging extras and install docs (#75); transformers constraint widen; unknown `active_model` raises `ConfigError`
- **Removed:** Dead providers/optional modules and no-op judge config fields (#77)
- **Added:** Deprecation shim coverage (#76); synthetic BIOES fixture; CI wheel-only `[ml]` resolve on 3.13

Python 3.13 install was fixed in 0.5.1; this release is robustness, usability, and YAGNI.

## Release flow
After merge: promote `dev` → `main`, then publish GitHub Release `v0.5.2` (triggers `publish-pypi.yml`).

## Test plan
- [x] `make check-ci` green locally
- [ ] PR CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release metadata with no runtime code changes.
> 
> **Overview**
> **Patch release 0.5.2** — bumps the published SDK version from `0.5.1` to `0.5.2` in `pyproject.toml`, the `__init__.py` fallback when the package isn’t installed, and `uv.lock`.
> 
> **CHANGELOG** — renames `[Unreleased]` to **`[0.5.2] — 2026-07-20`** so the notes already on `dev` (ML/model-store hardening, packaging/docs, dead-module removal, new tests/CI) ship with this tag. No functional code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b70f91d09ef2e7f82b0658d872a91e286a445245. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->