### PR TITLE
Fix Guard(config=) mode and strict_scanner_allowlist loading

### DIFF
--- a/sdk/src/unplug/config/loader.py
+++ b/sdk/src/unplug/config/loader.py
@@ -21,6 +21,47 @@ from unplug.config.limits import LimitConfig
 from unplug.config.messages import MessageConfig
 from unplug.config.policy import MlGateConfig, ScanPolicy
 from unplug.config.tools import ToolPolicyConfig
+from unplug.exceptions import ConfigError
+
+_GUARD_SECTION_KEYS: frozenset[str] = frozenset(
+    {
+        "scanners",
+        "mode",
+        "server_url",
+        "server_api_key",
+        "policy",
+        "cache",
+        "fail_closed",
+        "pipeline",
+        "scanners_config",
+        "limits",
+        "messages",
+        "judge_enabled",
+        "judge_low",
+        "judge_high",
+        "models",
+        "active_model",
+        "auto_download_model",
+        "require_ml",
+        "tools",
+        "boundaries",
+        "trajectory",
+        "intent",
+        "degradation",
+        "toolchain",
+        "collusion",
+        "strict_scanner_allowlist",
+    }
+)
+
+
+def _reject_unknown_guard_keys(data: dict[str, Any]) -> None:
+    if "guard" not in data:
+        return
+    unknown = sorted(set(data["guard"]) - _GUARD_SECTION_KEYS)
+    if unknown:
+        msg = f"Unknown [guard] config keys: {', '.join(unknown)}"
+        raise ConfigError(msg)
 
 
 def load_from_file(path: str | Path) -> dict[str, Any]:
@@ -218,6 +259,7 @@ def _build_collusion(data: dict[str, Any]) -> CollusionConfig:
 
 def build_config(data: dict[str, Any]) -> GuardConfig:
     """Build a GuardConfig from a raw dict (from TOML or env)."""
+    _reject_unknown_guard_keys(data)
     guard_data = data.get("guard", data)
     kwargs: dict[str, Any] = {}
 
@@ -237,6 +279,8 @@ def build_config(data: dict[str, Any]) -> GuardConfig:
         )
     if "fail_closed" in guard_data:
         kwargs["fail_closed"] = guard_data["fail_closed"]
+    if "strict_scanner_allowlist" in guard_data:
+        kwargs["strict_scanner_allowlist"] = bool(guard_data["strict_scanner_allowlist"])
 
     pipeline_data = guard_data.get("pipeline", data.get("pipeline", {}))
     if pipeline_data:

--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -100,7 +100,7 @@ class Guard:
         self,
         *,
         scanners: list[str] | None = None,
-        mode: str = "local",
+        mode: str | None = None,
         server_url: str | None = None,
         server_api_key: str | None = None,
         fail_mode: str = "closed",
@@ -123,7 +123,9 @@ class Guard:
                 DeprecationWarning,
                 stacklevel=2,
             )
-        overrides: dict[str, Any] = {"mode": mode, "fail_closed": fail_mode == "closed"}
+        overrides: dict[str, Any] = {"fail_closed": fail_mode == "closed"}
+        if mode is not None:
+            overrides["mode"] = mode
         if scanners is not None:
             overrides["scanners"] = scanners
         if server_url is not None:

--- a/sdk/tests/integration/test_guard_server_mode.py
+++ b/sdk/tests/integration/test_guard_server_mode.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from unplug import Guard
 from unplug.api.enums import Action
+from unplug.config.guard import GuardConfig
 from unplug.models import ScanResult
 
 
@@ -50,3 +51,18 @@ class TestGuardServerMode:
             out = guard.scan_request(req)
         assert out.safe is True
         mock_cls.return_value.scan_request.assert_called_once()
+
+    def test_config_server_mode_not_overridden_by_default(self) -> None:
+        cfg = GuardConfig(mode="server", server_url="http://unplug.test")
+        with patch("unplug.guard.UnplugClient") as mock_cls:
+            guard = Guard(config=cfg)
+        assert guard.config.mode == "server"
+        assert guard.is_server_mode is True
+        mock_cls.assert_called_once_with(base_url="http://unplug.test", api_key=None)
+
+    def test_explicit_mode_overrides_config(self) -> None:
+        cfg = GuardConfig(mode="server", server_url="http://unplug.test")
+        with patch("unplug.guard.UnplugClient"):
+            guard = Guard(config=cfg, mode="local")
+        assert guard.config.mode == "local"
+        assert guard.is_server_mode is False

--- a/sdk/tests/unit/config/test_config_loader.py
+++ b/sdk/tests/unit/config/test_config_loader.py
@@ -134,6 +134,16 @@ class TestBuildConfig:
         assert "injection" in cfg.scanner_configs
         assert cfg.scanner_configs["injection"].base_score == 0.9
 
+    def test_strict_scanner_allowlist_from_guard_section(self) -> None:
+        cfg = build_config({"guard": {"strict_scanner_allowlist": True}})
+        assert cfg.strict_scanner_allowlist is True
+
+    def test_unknown_guard_key_raises(self) -> None:
+        from unplug.exceptions import ConfigError
+
+        with pytest.raises(ConfigError, match="Unknown \\[guard\\] config keys"):
+            build_config({"guard": {"strict_scanner_allowlist_typo": True}})
+
 
 class TestLoad:
     def test_from_file(self, toml_file: Path):
@@ -245,6 +255,15 @@ blocked_tools = ["danger"]
         cfg = load(file_path=p)
         assert cfg.limits.max_input_chars == 100
         assert cfg.limits.blocked_tools == ["danger"]
+
+    def test_strict_scanner_allowlist_from_toml(self, tmp_path: Path) -> None:
+        p = tmp_path / "unplug.toml"
+        p.write_text("""\
+[guard]
+strict_scanner_allowlist = true
+""")
+        cfg = load(file_path=p)
+        assert cfg.strict_scanner_allowlist is True
 
     def test_messages_from_toml(self, tmp_path: Path) -> None:
         p = tmp_path / "unplug.toml"


### PR DESCRIPTION
## Summary
- Only apply `mode=` override when the caller explicitly passes it; `Guard(config=GuardConfig(mode="server"))` now keeps server mode and builds the HTTP client
- Parse `strict_scanner_allowlist` from TOML/`build_config` and reject unknown `[guard]` keys with `ConfigError`

Fixes #85

## Test plan
- [x] `make check`
- [x] `make test-cov`
- [x] New tests for config server mode, TOML strict allowlist round-trip, unknown guard keys