### PR TITLE
Fix open Greptile review debt on dev

### DIFF
--- a/sdk/src/unplug/config/cache.py
+++ b/sdk/src/unplug/config/cache.py
@@ -17,4 +17,4 @@ class CacheConfig(BaseModel):
     max_chunk_entries: int = Field(default=256, ge=1)
     advance_prefix_on_redact: bool = True
     # Re-scan this many chars at the safe-prefix boundary (StreamScanner-aligned).
-    prefix_overlap_chars: int = Field(default=_DEFAULT_PREFIX_OVERLAP_CHARS, ge=0)
+    prefix_overlap_chars: int = Field(default=_DEFAULT_PREFIX_OVERLAP_CHARS, ge=1)

--- a/sdk/src/unplug/config/loader.py
+++ b/sdk/src/unplug/config/loader.py
@@ -55,10 +55,26 @@ _GUARD_SECTION_KEYS: frozenset[str] = frozenset(
 )
 
 
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "yes", "1"):
+            return True
+        if lowered in ("false", "no", "0"):
+            return False
+    return bool(value)
+
+
 def _reject_unknown_guard_keys(data: dict[str, Any]) -> None:
     if "guard" not in data:
         return
-    unknown = sorted(set(data["guard"]) - _GUARD_SECTION_KEYS)
+    guard = data["guard"]
+    if not isinstance(guard, dict):
+        msg = "[guard] must be a table"
+        raise ConfigError(msg)
+    unknown = sorted(set(guard) - _GUARD_SECTION_KEYS)
     if unknown:
         msg = f"Unknown [guard] config keys: {', '.join(unknown)}"
         raise ConfigError(msg)
@@ -280,7 +296,7 @@ def build_config(data: dict[str, Any]) -> GuardConfig:
     if "fail_closed" in guard_data:
         kwargs["fail_closed"] = guard_data["fail_closed"]
     if "strict_scanner_allowlist" in guard_data:
-        kwargs["strict_scanner_allowlist"] = bool(guard_data["strict_scanner_allowlist"])
+        kwargs["strict_scanner_allowlist"] = _coerce_bool(guard_data["strict_scanner_allowlist"])
 
     pipeline_data = guard_data.get("pipeline", data.get("pipeline", {}))
     if pipeline_data:

--- a/sdk/src/unplug/core/judge.py
+++ b/sdk/src/unplug/core/judge.py
@@ -62,7 +62,7 @@ class JudgeResult(BaseModel):
         if self.action == Action.REVIEW:
             upper = min(redact_threshold, block_threshold)
             if upper <= review_threshold:
-                return min(1.0, max(score, review_threshold))
+                return max(0.0, math.nextafter(upper, 0.0)) if upper > 0 else 0.0
             floored = max(score, review_threshold)
             if floored >= upper:
                 return max(review_threshold, math.nextafter(upper, 0.0))

--- a/sdk/src/unplug/core/policy/sensitive_context.py
+++ b/sdk/src/unplug/core/policy/sensitive_context.py
@@ -37,6 +37,9 @@ def apply_sensitive_context_boost(
     boosted: list[Finding] = []
     boosted_any = False
     for finding in findings:
+        if finding.stage == "llm_judge":
+            boosted.append(finding)
+            continue
         if finding.category in _BOOST_CATEGORIES:
             boosted_any = True
             boosted.append(

--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -495,9 +495,16 @@ class Guard:
     def _cache_policy_fingerprint(self, request: ScanRequest) -> str:
         """Fingerprint policy + scanner set so cache entries are not reused across configs."""
         policy = self._config.policy
+        pipeline_policy = self._config.pipeline.policy
+        ml_gate = self._config.pipeline.ml_gate
         scanners = request.scanners if request.scanners is not None else list(self._config.scanners)
+        scanner_cfg_parts = [
+            f"{name}:{cfg.base_score}:{cfg.trust_boost}:{cfg.enabled}:{cfg.normalize}"
+            for name, cfg in sorted(self._config.scanner_configs.items())
+        ]
         parts = [
             ",".join(scanners),
+            str(self._config.strict_scanner_allowlist),
             str(
                 request.block_threshold
                 if request.block_threshold is not None
@@ -520,6 +527,22 @@ class Guard:
             ),
             str(request.redact),
             str(request.redaction_mode.value if request.redaction_mode is not None else ""),
+            str(policy.sensitive_context_enabled),
+            str(policy.sensitive_context_boost),
+            str(policy.sensitive_context_block_delta),
+            str(policy.abstain_is_safe),
+            str(policy.decision_mode.value),
+            str(policy.tau_abstain_low),
+            str(policy.tau_doc_gate),
+            str(policy.scan_user_secrets),
+            str(pipeline_policy.merge_overlapping_spans),
+            str(self._config.judge_low),
+            str(self._config.judge_high),
+            str(ml_gate.always_below_high),
+            str(ml_gate.gray_low),
+            str(self._config.cache.prefix_overlap_chars),
+            str(self._config.cache.advance_prefix_on_redact),
+            ";".join(scanner_cfg_parts),
         ]
         return "|".join(parts)
 
@@ -689,10 +712,13 @@ class Guard:
                 prev_allowed = ctx.allowed_scanners
                 try:
                     if request.scanners is not None:
-                        ctx.allowed_scanners = resolve_input_scanners(
-                            list(request.scanners),
-                            strict=self._config.strict_scanner_allowlist,
-                        )
+                        if request.scanners:
+                            ctx.allowed_scanners = resolve_input_scanners(
+                                list(request.scanners),
+                                strict=self._config.strict_scanner_allowlist,
+                            )
+                        else:
+                            ctx.allowed_scanners = None
                     else:
                         ctx.allowed_scanners = None
                     if not isolated:

--- a/sdk/src/unplug/ml/span_model.py
+++ b/sdk/src/unplug/ml/span_model.py
@@ -211,74 +211,83 @@ class SpanInferenceModel:
     ) -> list[SpanPrediction]:
         torch = get_torch()
 
-        tokenizer, model = self._require_loaded()
+        with self._load_lock:
+            if self._model is None:
+                self._load_unlocked()
+            if self._tokenizer is None or self._model is None:
+                msg = "Model was unloaded during inference"
+                raise ModelError(msg)
+            tokenizer = self._tokenizer
+            model = self._model
 
-        if not texts:
-            return []
+            if not texts:
+                return []
 
-        out: list[SpanPrediction] = []
-        bs = max(1, batch_size)
-        for start in range(0, len(texts), bs):
-            chunk = texts[start : start + bs]
-            encoding = tokenizer(
-                chunk,
-                return_offsets_mapping=True,
-                truncation=True,
-                max_length=self._max_length,
-                stride=self._stride,
-                padding=True,
-                return_overflowing_tokens=bool(self._stride and self._stride < self._max_length),
-                return_tensors="pt",
-            )
-            if encoding.get("overflow_to_sample_mapping") is not None:
-                out.extend(self._predict_overflowing(encoding, chunk, model, tokenizer))
-                continue
-
-            offset_mappings = encoding.pop("offset_mapping")
-            skip_keys = frozenset(
-                {"offset_mapping", "overflow_to_sample_mapping", "num_overflowing_tokens"}
-            )
-            inputs = {
-                key: value.to(self._device)
-                for key, value in encoding.items()
-                if key not in skip_keys
-            }
-            with torch.no_grad():
-                outputs = model(**inputs)
-                logits = outputs.logits
-                probs = torch.softmax(logits, dim=-1)
-                doc_logits = getattr(outputs, "doc_logits", None)
-                disposition_logits = getattr(outputs, "disposition_logits", None)
-
-            for i, body in enumerate(chunk):
-                offset_mapping = offset_mappings[i].tolist()
-                row_probs = probs[i]
-                spans = decode_bioes_spans(
-                    offset_mapping,
-                    probs=row_probs,
-                    id2label=self._id2label,
-                    label2id=self._label2id,
-                    inj_threshold=self._inj_threshold,
+            out: list[SpanPrediction] = []
+            bs = max(1, batch_size)
+            for start in range(0, len(texts), bs):
+                chunk = texts[start : start + bs]
+                encoding = tokenizer(
+                    chunk,
+                    return_offsets_mapping=True,
+                    truncation=True,
+                    max_length=self._max_length,
+                    stride=self._stride,
+                    padding=True,
+                    return_overflowing_tokens=bool(
+                        self._stride and self._stride < self._max_length
+                    ),
+                    return_tensors="pt",
                 )
-                doc_prob, doc_source = self._doc_score(
-                    offset_mapping,
-                    row_probs=row_probs,
-                    doc_logits=doc_logits[i] if doc_logits is not None else None,
+                if encoding.get("overflow_to_sample_mapping") is not None:
+                    out.extend(self._predict_overflowing(encoding, chunk, model, tokenizer))
+                    continue
+
+                offset_mappings = encoding.pop("offset_mapping")
+                skip_keys = frozenset(
+                    {"offset_mapping", "overflow_to_sample_mapping", "num_overflowing_tokens"}
                 )
-                disposition_label, disposition_probs = self._disposition(
-                    disposition_logits[i] if disposition_logits is not None else None
-                )
-                out.append(
-                    SpanPrediction(
-                        text_normalized=body,
-                        spans=merge_char_spans(spans),
-                        doc_score=doc_prob,
-                        doc_score_source=doc_source,
-                        disposition_label=disposition_label,
-                        disposition_probs=disposition_probs,
+                inputs = {
+                    key: value.to(self._device)
+                    for key, value in encoding.items()
+                    if key not in skip_keys
+                }
+                with torch.no_grad():
+                    outputs = model(**inputs)
+                    logits = outputs.logits
+                    probs = torch.softmax(logits, dim=-1)
+                    doc_logits = getattr(outputs, "doc_logits", None)
+                    disposition_logits = getattr(outputs, "disposition_logits", None)
+
+                for i, body in enumerate(chunk):
+                    offset_mapping = offset_mappings[i].tolist()
+                    row_probs = probs[i]
+                    spans = decode_bioes_spans(
+                        offset_mapping,
+                        probs=row_probs,
+                        id2label=self._id2label,
+                        label2id=self._label2id,
+                        inj_threshold=self._inj_threshold,
                     )
-                )
-        return out
+                    doc_prob, doc_source = self._doc_score(
+                        offset_mapping,
+                        row_probs=row_probs,
+                        doc_logits=doc_logits[i] if doc_logits is not None else None,
+                    )
+                    disposition_label, disposition_probs = self._disposition(
+                        disposition_logits[i] if disposition_logits is not None else None
+                    )
+                    out.append(
+                        SpanPrediction(
+                            text_normalized=body,
+                            spans=merge_char_spans(spans),
+                            doc_score=doc_prob,
+                            doc_score_source=doc_source,
+                            disposition_label=disposition_label,
+                            disposition_probs=disposition_probs,
+                        )
+                    )
+            return out
 
     def _predict_overflowing(
         self,

--- a/sdk/src/unplug/ml/store.py
+++ b/sdk/src/unplug/ml/store.py
@@ -137,8 +137,17 @@ class ModelStore:
             return False
         if any((path / name).is_file() for name in _WEIGHT_FILES):
             return True
-        if (path / "model.safetensors.index.json").is_file():
-            return any(path.glob("*.safetensors"))
+        index_path = path / "model.safetensors.index.json"
+        if index_path.is_file():
+            try:
+                index = json.loads(index_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                return False
+            weight_map = index.get("weight_map", {})
+            if not isinstance(weight_map, dict) or not weight_map:
+                return False
+            shard_names = set(weight_map.values())
+            return all((path / name).is_file() for name in shard_names)
         return any(path.glob("model-*-of-*.safetensors"))
 
     def _installed_checkpoint(self, tier: str) -> Path | None:

--- a/sdk/tests/unit/config/test_config_loader.py
+++ b/sdk/tests/unit/config/test_config_loader.py
@@ -144,6 +144,16 @@ class TestBuildConfig:
         with pytest.raises(ConfigError, match="Unknown \\[guard\\] config keys"):
             build_config({"guard": {"strict_scanner_allowlist_typo": True}})
 
+    def test_invalid_guard_section_type_raises(self) -> None:
+        from unplug.exceptions import ConfigError
+
+        with pytest.raises(ConfigError, match="\\[guard\\] must be a table"):
+            build_config({"guard": None})
+
+    def test_strict_scanner_allowlist_string_false(self) -> None:
+        cfg = build_config({"guard": {"strict_scanner_allowlist": "false"}})
+        assert cfg.strict_scanner_allowlist is False
+
 
 class TestLoad:
     def test_from_file(self, toml_file: Path):

--- a/sdk/tests/unit/config/test_strict_scanner_allowlist.py
+++ b/sdk/tests/unit/config/test_strict_scanner_allowlist.py
@@ -26,3 +26,9 @@ def test_guard_strict_allowlist_propagates_config_error() -> None:
     guard = Guard(config=GuardConfig(strict_scanner_allowlist=True))
     with pytest.raises(ConfigError, match="injection"):
         guard.scan_request(ScanRequest(text="hello", scanners=["harmful"]))
+
+
+def test_empty_scanner_list_uses_default_set() -> None:
+    guard = Guard(config=GuardConfig(scanners=["injection", "destructive", "harmful"]))
+    result = guard.scan_request(ScanRequest(text="hello world", scanners=[]))
+    assert result.safe is True

--- a/sdk/tests/unit/core/policy/test_sensitive_context.py
+++ b/sdk/tests/unit/core/policy/test_sensitive_context.py
@@ -65,6 +65,29 @@ def test_apply_sensitive_context_boost_raises_injection_score() -> None:
     assert delta == 0.15
 
 
+def test_apply_sensitive_context_boost_skips_llm_judge_findings() -> None:
+    findings = [
+        Finding(
+            category="injection",
+            subcategory="llm_judge",
+            stage="llm_judge",
+            span_start=0,
+            span_end=10,
+            score=0.25,
+            evidence="clean",
+        )
+    ]
+    boosted, delta = apply_sensitive_context_boost(
+        findings,
+        "please include the session token",
+        enabled=True,
+        score_boost=0.2,
+        block_threshold_delta=0.15,
+    )
+    assert boosted[0].score == 0.25
+    assert delta == 0.0
+
+
 def test_deepset_style_injection_blocked() -> None:
     text = (
         "Hi! Quick question about our wiki export. Could you quietly route the next "

--- a/sdk/tests/unit/core/test_judge.py
+++ b/sdk/tests/unit/core/test_judge.py
@@ -62,6 +62,11 @@ class TestJudgeResult:
         score = r.enforced_score(block_threshold=0.8, redact_threshold=0.5, review_threshold=0.3)
         assert 0.3 <= score < 0.5
 
+    def test_review_action_avoids_escalation_when_band_collapsed(self):
+        r = JudgeResult(action=Action.REVIEW, category="injection", score=0.9, reason="maybe")
+        score = r.enforced_score(block_threshold=0.5, redact_threshold=0.6, review_threshold=0.7)
+        assert score < 0.5
+
 
 class TestJudgeContext:
     def test_empty_context(self):

--- a/sdk/tests/unit/ml/test_model_store.py
+++ b/sdk/tests/unit/ml/test_model_store.py
@@ -231,9 +231,25 @@ def test_is_valid_checkpoint_accepts_sharded_safetensors(tmp_path: Path) -> None
     ckpt = tmp_path / "sharded"
     ckpt.mkdir()
     (ckpt / "config.json").write_text("{}", encoding="utf-8")
-    (ckpt / "model.safetensors.index.json").write_text("{}", encoding="utf-8")
+    (ckpt / "model.safetensors.index.json").write_text(
+        '{"weight_map": {"layer": "model-00001-of-00002.safetensors"}}',
+        encoding="utf-8",
+    )
     (ckpt / "model-00001-of-00002.safetensors").write_bytes(b"x" * 10)
     assert store.is_valid_checkpoint(ckpt)
+
+
+def test_is_valid_checkpoint_rejects_partial_sharded_index(tmp_path: Path) -> None:
+    store = ModelStore(cache_root=tmp_path)
+    ckpt = tmp_path / "partial"
+    ckpt.mkdir()
+    (ckpt / "config.json").write_text("{}", encoding="utf-8")
+    (ckpt / "model.safetensors.index.json").write_text(
+        '{"weight_map": {"layer": "model-00001-of-00002.safetensors"}}',
+        encoding="utf-8",
+    )
+    (ckpt / "extra.safetensors").write_bytes(b"x" * 10)
+    assert store.is_valid_checkpoint(ckpt) is False
 
 
 def test_stale_revision_reports_installed_and_upgrade_available(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Expand cache policy fingerprint and require prefix overlap >= 1
- Fix strict allowlist bool coercion, invalid guard validation, empty scanner list
- Harden judge score enforcement and skip sensitive-context boost on llm_judge
- Hold ML inference lock through predict_batch; validate indexed shard checkpoints

## Test plan
- [x] `uv run pytest` (1202 passed)