### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,29 @@ All notable changes to the `unplug-ai` SDK.
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-07-20
+
+### Security
+
+- Safe-prefix cache: re-scan overlap at chunk boundaries and scope cache keys by source + policy fingerprint so split injection phrases and cross-source ALLOW reuse cannot bypass detection (#87, fixes #82/#83)
+- Per-request `scanners=` allowlist no longer sticks on the shared `ExecutionContext`; omitted `scanners` clears the allowlist so later scans use the full configured set (#88, fixes #84)
+- `Guard(config=GuardConfig(mode=...))` keeps the configured mode when `mode=` is not passed; `strict_scanner_allowlist` loads from TOML/`build_config`; unknown `[guard]` keys raise `ConfigError` (#89, fixes #85)
+- Judge `action=block` / `review` / `allow` clamps finding scores so declared verdicts drive enforcement even when the LLM returns an inconsistent score (#90, fixes #86)
+- Follow-up hardening from review debt: cache policy fingerprint + prefix overlap ≥ 1, strict-allowlist coercion, judge score enforcement, skip sensitive-context boost on `llm_judge`, hold ML inference lock through `predict_batch`, validate indexed shard checkpoints (#91)
+
+### Added
+
+- Public `LimitConfig` / BYOLLM judge surface (`unplug`, `unplug.api.limits`, `unplug.api.judge`) with docs, example, and TOML notes (#80)
+- Focused injection regex patterns from neuralchemy FN sampling; bidi control stripping in the normalizer (#80)
+- Pre-0.6.0 local test harness: `make test-frameworks`, `test-ml-harness`, `smoke-ml-hooks`, `test-all-local` plus `sdk/docs/TESTING_HARNESS.md` (#92)
+
 ### Fixed
 
-- Judge `action=block` (and `review`/`allow`) now clamps finding scores so score-driven policy honors the declared verdict even when the LLM returns an inconsistent score
+- Post-merge review follow-ups across promote/Phase C: `unplug-scan` pin, AG2 multimodal redaction, model download flock/staging, tighter `instructions_updated_supersede` regex, `NORMALIZER_VERSION` bump, sharded safetensors checkpoints (#81)
+
+### Changed
+
+- Eval docs refreshed (`EVAL_PHASE_C.md` / benchmarks); regex neuralchemy recall/F1 improved modestly after pattern expansion (#80)
 
 ## [0.5.2] — 2026-07-20
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "unplug-ai"
-version = "0.5.2"
+version = "0.6.0"
 description = "Unplug the bad AI. Fast prompt injection detection and redaction for LLM apps, agents, and RAG pipelines."
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/src/unplug/__init__.py
+++ b/sdk/src/unplug/__init__.py
@@ -78,7 +78,7 @@ try:
     # Single source of truth is pyproject.toml; avoids version drift.
     __version__ = _pkg_version("unplug-ai")
 except PackageNotFoundError:  # not installed (e.g. running from a source checkout)
-    __version__ = "0.5.2"
+    __version__ = "0.6.0"
 
 
 def __getattr__(name: str) -> object:

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -6910,7 +6910,7 @@ wheels = [
 
 [[package]]
 name = "unplug-ai"
-version = "0.5.2"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Cuts **unplug-ai 0.6.0** (minor from 0.5.2). Shipping content is already on `dev` (#80–#92).

- `version` 0.5.2 → 0.6.0 (`pyproject.toml`, `__init__.py` fallback, `uv.lock`)
- CHANGELOG `[Unreleased]` → `[0.6.0] — 2026-07-20` (empty `[Unreleased]` kept)

### What's in 0.6.0 (since 0.5.2)
- **Security:** Safe-prefix cache boundary bypass (#87/#82/#83); scanner allowlist sticky state (#88/#84); Guard config mode + strict allowlist loading (#89/#85); judge score/action enforcement (#90/#86); review-debt hardening (#91)
- **Added:** Public LimitConfig / BYOLLM judge API (#80); injection regex + bidi normalizer (#80); local test harness make targets + `TESTING_HARNESS.md` (#92)
- **Fixed:** Post-merge review follow-ups from #71/#79/#80 (#81)

## Release flow
After merge: promote `dev` → `main`, then publish GitHub Release `v0.6.0` (triggers `publish-pypi.yml`).

## Test plan
- [x] Local pytest (1203 passed) + scenarios + attack-gate
- [ ] PR CI green