### PR TITLE
fix(config): remove the dead GuardConfig.fail_closed field (closes #103)

### DIFF
--- a/sdk/src/unplug/config/guard.py
+++ b/sdk/src/unplug/config/guard.py
@@ -96,7 +96,6 @@ class GuardConfig(BaseModel):
     mode: str = "local"
     server_url: str | None = None
     server_api_key: str | None = None
-    fail_closed: bool = True
     pipeline: PipelineConfig = Field(default_factory=PipelineConfig)
     policy: ScanPolicy = Field(
         default_factory=ScanPolicy,

--- a/sdk/src/unplug/config/loader.py
+++ b/sdk/src/unplug/config/loader.py
@@ -31,6 +31,9 @@ _GUARD_SECTION_KEYS: frozenset[str] = frozenset(
         "server_api_key",
         "policy",
         "cache",
+        # Removed from GuardConfig, but still accepted here so an existing
+        # unplug.toml gets the deprecation warning below rather than a
+        # hard "unknown key" ConfigError.
         "fail_closed",
         "pipeline",
         "scanners_config",
@@ -293,8 +296,6 @@ def build_config(data: dict[str, Any]) -> GuardConfig:
         kwargs["cache"] = CacheConfig(
             **{k: v for k, v in guard_data["cache"].items() if k in CacheConfig.model_fields}
         )
-    if "fail_closed" in guard_data:
-        kwargs["fail_closed"] = guard_data["fail_closed"]
     if "strict_scanner_allowlist" in guard_data:
         kwargs["strict_scanner_allowlist"] = _coerce_bool(guard_data["strict_scanner_allowlist"])
 

--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -123,7 +123,7 @@ class Guard:
                 DeprecationWarning,
                 stacklevel=2,
             )
-        overrides: dict[str, Any] = {"fail_closed": fail_mode == "closed"}
+        overrides: dict[str, Any] = {}
         if mode is not None:
             overrides["mode"] = mode
         if scanners is not None:

--- a/sdk/tests/integration/test_infrastructure.py
+++ b/sdk/tests/integration/test_infrastructure.py
@@ -54,7 +54,6 @@ class TestGuardConfig:
         c = GuardConfig()
         assert "injection" in c.scanners
         assert c.mode == "local"
-        assert c.fail_closed is True
 
     def test_get_scanner_config_default(self):
         c = GuardConfig()

--- a/sdk/tests/unit/config/test_config_loader.py
+++ b/sdk/tests/unit/config/test_config_loader.py
@@ -184,6 +184,16 @@ class TestLoad:
             for w in caught
         )
 
+    def test_fail_closed_is_not_a_config_field(self) -> None:
+        """The key is accepted for back-compat but no longer materialises on the model."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            cfg = build_config({"guard": {"fail_closed": False}})
+        assert "fail_closed" not in GuardConfig.model_fields
+        assert not hasattr(cfg, "fail_closed")
+
     def test_judge_enabled_warns(self) -> None:
         import warnings
 
@@ -223,9 +233,9 @@ class TestLoad:
         assert cfg == GuardConfig()
 
     def test_env_only(self):
-        with patch.dict(os.environ, {"UNPLUG_GUARD__FAIL_CLOSED": "false"}):
+        with patch.dict(os.environ, {"UNPLUG_GUARD__STRICT_SCANNER_ALLOWLIST": "true"}):
             cfg = load()
-        assert cfg.fail_closed is False
+        assert cfg.strict_scanner_allowlist is True
 
     def test_env_model_path_sets_active_model(self, tmp_path: Path) -> None:
         ckpt = tmp_path / "ckpt"


### PR DESCRIPTION
Closes #103.

`GuardConfig.fail_closed` was defined but never read. Errors always fail closed regardless of its value, so the field did nothing except suggest it was a working switch.

## What changed

- `config/guard.py` — dropped the `fail_closed` field.
- `guard.py` — `Guard.__init__` no longer builds a `{"fail_closed": ...}` override from the deprecated `fail_mode` argument. The `fail_mode="open"` DeprecationWarning above it is untouched.
- `config/loader.py` — dropped the `[guard] fail_closed` passthrough into `kwargs`.

## The one thing worth reviewing

`fail_closed` is **kept** in `_GUARD_SECTION_KEYS`. `_reject_unknown_guard_keys` raises `ConfigError` for any `[guard]` key not in that set, so removing it there would turn an existing `unplug.toml` with `fail_closed = false` from "warns and explains itself" into a hard startup failure. There's a comment at the definition saying so.

The deprecation warning in `build_config` reads the raw config dict, not the model, so it still fires with the field gone — the existing `test_fail_closed_false_warns` and `test_fail_closed_false_warns_on_init` both still pass unchanged.

## Tests

- `test_env_only` used `UNPLUG_GUARD__FAIL_CLOSED` purely as a vehicle for proving env vars reach the config; repointed at `strict_scanner_allowlist` so it keeps testing env-var plumbing.
- One assertion removed from `TestGuardConfig::test_defaults`.
- Added `test_fail_closed_is_not_a_config_field`, which pins both halves: the key is still accepted by the loader, and it no longer materialises on the model.
- The `toml_file` fixture still writes `fail_closed = true`, so the back-compat path stays exercised.

Ran locally on Windows / Python 3.12:

- `uv run pytest tests/unit tests/integration` — 880 passed, 32 skipped
- `uv run pytest tests/security` — 180 passed
- `ruff check src tests` and `ruff format --check src tests` — clean

`sdk/MIGRATION.md` already lists `fail_closed` under removed config, so this brings the code in line with the documented state rather than changing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)