### PR TITLE
refactor(guard): write the degraded-ML warning in one place (closes #104)

### DIFF
--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -188,15 +188,7 @@ class Guard:
                         f"require_ml=true but model tier {tier!r} could not be loaded: "
                         f"{type(exc).__name__}: {exc}"
                     ) from exc
-                _log.warning(
-                    "active_model=%s configured but injection_ml failed to load (%s). "
-                    'Fix: pip install "unplug-ai[ml]", then unplug-models download %s '
-                    "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only.",
-                    cfg.active_model,
-                    type(exc).__name__,
-                    cfg.active_model,
-                )
-                self._ml_degraded = True
+                self._mark_ml_degraded(cfg.active_model, exc=exc)
             if provider is not None and spec is not None:
                 self._ml_provider = provider
                 self._model_cache_version = model_cache_version(spec)
@@ -206,14 +198,7 @@ class Guard:
                     f"Run: unplug-models download {cfg.active_model}"
                 )
             elif load_error is None:
-                _log.warning(
-                    "active_model=%s configured but injection_ml is not loaded. "
-                    'Fix: pip install "unplug-ai[ml]", then unplug-models download %s '
-                    "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only.",
-                    cfg.active_model,
-                    cfg.active_model,
-                )
-                self._ml_degraded = True
+                self._mark_ml_degraded(cfg.active_model)
 
         v2_scanners = self._registry.get_many(scanner_names, configs=cfg.scanner_configs)
         if self._ml_provider is not None:
@@ -267,6 +252,24 @@ class Guard:
             trajectory_config=cfg.trajectory,
             degradation_config=cfg.degradation,
         )
+
+    def _mark_ml_degraded(self, tier: str, *, exc: Exception | None = None) -> None:
+        """Record that ML scanning is unavailable and say so once.
+
+        `exc` distinguishes a model that raised while loading from one that
+        simply never materialised; everything else about the warning is the
+        same, so it is written in one place.
+        """
+        reason = f"failed to load ({type(exc).__name__})" if exc is not None else "is not loaded"
+        _log.warning(
+            "active_model=%s configured but injection_ml %s. "
+            'Fix: pip install "unplug-ai[ml]", then unplug-models download %s '
+            "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only.",
+            tier,
+            reason,
+            tier,
+        )
+        self._ml_degraded = True
 
     @property
     def context(self) -> ExecutionContext:

--- a/sdk/tests/unit/ml/test_ml_degraded_warning.py
+++ b/sdk/tests/unit/ml/test_ml_degraded_warning.py
@@ -1,0 +1,70 @@
+"""The degraded-ML warning is written in one place but still names its cause."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from unplug.config.guard import GuardConfig
+from unplug.guard import Guard
+
+_FIX_HINT = (
+    'Fix: pip install "unplug-ai[ml]", then unplug-models download tiny '
+    "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only."
+)
+
+
+@pytest.fixture
+def tiny_config() -> GuardConfig:
+    return GuardConfig(active_model="tiny", scanners=["injection"])
+
+
+def test_load_failure_names_the_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    tiny_config: GuardConfig,
+) -> None:
+    def boom(_cfg: GuardConfig) -> None:
+        raise RuntimeError("no weights here")
+
+    monkeypatch.setattr("unplug.guard.prepare_active_model_spec", boom)
+
+    with caplog.at_level(logging.WARNING, logger="unplug.guard"):
+        guard = Guard(config=tiny_config)
+
+    assert guard.ml_degraded is True
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings == [
+        f"active_model=tiny configured but injection_ml failed to load (RuntimeError). {_FIX_HINT}"
+    ]
+
+
+def test_missing_model_says_not_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    tiny_config: GuardConfig,
+) -> None:
+    monkeypatch.setattr("unplug.guard.prepare_active_model_spec", lambda _cfg: None)
+
+    with caplog.at_level(logging.WARNING, logger="unplug.guard"):
+        guard = Guard(config=tiny_config)
+
+    assert guard.ml_degraded is True
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings == [f"active_model=tiny configured but injection_ml is not loaded. {_FIX_HINT}"]
+
+
+def test_warning_is_emitted_once_per_guard(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    tiny_config: GuardConfig,
+) -> None:
+    """The point of the helper: neither path can log the message twice."""
+    monkeypatch.setattr("unplug.guard.prepare_active_model_spec", lambda _cfg: None)
+
+    with caplog.at_level(logging.WARNING, logger="unplug.guard"):
+        Guard(config=tiny_config)
+
+    degraded = [r for r in caplog.records if "injection_ml" in r.getMessage()]
+    assert len(degraded) == 1


### PR DESCRIPTION
Closes #104.

`Guard.__init__` logged the "active_model configured but ML not loaded" warning from two branches that differed only in whether an exception had been caught, and both set `self._ml_degraded = True`.

## What changed

Both blocks now call a single helper:

```python
def _mark_ml_degraded(self, tier: str, *, exc: Exception | None = None) -> None:
    reason = f"failed to load ({type(exc).__name__})" if exc is not None else "is not loaded"
    _log.warning(
        "active_model=%s configured but injection_ml %s. "
        'Fix: pip install "unplug-ai[ml]", then unplug-models download %s '
        "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only.",
        tier, reason, tier,
    )
    self._ml_degraded = True
```

Both call sites are kept, and both rendered messages are byte-for-byte what they were before — including the exception type name on the path that has one. The fix hint, which was the duplicated part, is now written once.

## How I know behaviour is identical

`tests/unit/ml/test_ml_degraded_warning.py` asserts the two full messages verbatim, plus `ml_degraded is True` and that exactly one warning is emitted per `Guard`.

I ran that file against **pristine `guard.py`** (`git stash push -- sdk/src/unplug/guard.py`) and all 3 tests pass there too. A refactor's test should characterise the old behaviour rather than only the new, so this is the property I wanted — and it means the tests stay meaningful as the safety net for the larger degraded-state reporting rework the issue mentions.

The tests monkeypatch `unplug.guard.prepare_active_model_spec` to raise / to return `None`, so they exercise both branches without needing the `ml` extra or a checkpoint — unlike `tests/integration/test_guard_ml.py`, they don't skip.

## Tests

Windows / Python 3.12:

- `uv run pytest tests/unit tests/integration tests/security` — 1062 passed, 32 skipped
- `ruff check src tests` and `ruff format --check src tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)