### PR TITLE
fix(guard): label fail-closed results with stage and real latency (closes #106)

### DIFF
--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import threading
+import time
 from typing import Any, ClassVar
 
 from unplug.api.enums import Action, Source
@@ -49,7 +50,13 @@ from unplug.streaming import StreamScanner, scan_stream
 _log = get_logger("guard")
 
 
-def _fail_closed(exc: Exception) -> ScanResult:
+def _fail_closed(exc: Exception, started: float) -> ScanResult:
+    """Blocking result for an internal guard error.
+
+    `started` is a `time.perf_counter()` reading taken before the work that
+    raised, so the result reports how long the caller actually waited rather
+    than claiming the block was instantaneous.
+    """
     return ScanResult(
         safe=False,
         action=Action.BLOCK,
@@ -65,7 +72,8 @@ def _fail_closed(exc: Exception) -> ScanResult:
                 evidence=f"Guard failed: {type(exc).__name__}",
             )
         ],
-        latency_ms=0.0,
+        latency_ms=(time.perf_counter() - started) * 1000,
+        stages_run=["error"],
     )
 
 
@@ -621,6 +629,7 @@ class Guard:
         violation = self._limits.check_input_length(request.text)
         if violation is not None:
             return _limit_result(violation, len(request.text))
+        started = time.perf_counter()
         try:
             with correlation_scope():
                 if self._server_client is not None:
@@ -633,7 +642,7 @@ class Guard:
                 return result
         except Exception as exc:
             _log.error("guard.scan_output_request failed: %s", exc)
-            return _fail_closed(exc)
+            return _fail_closed(exc, started)
 
     def check_tool_call(
         self,
@@ -674,6 +683,7 @@ class Guard:
             taint_sources=taint_sources or [],
             approved=None,
         )
+        started = time.perf_counter()
         try:
             with correlation_scope():
                 result = self._tool_pipeline.run(tc, context=self._context)
@@ -692,7 +702,7 @@ class Guard:
                 return result
         except Exception as exc:
             _log.error("guard.check_tool_call failed: %s", exc)
-            return _fail_closed(exc)
+            return _fail_closed(exc, started)
 
     def scan_request(
         self,
@@ -704,6 +714,7 @@ class Guard:
         violation = self._limits.check_input_length(request.text)
         if violation is not None:
             return _limit_result(violation, len(request.text))
+        started = time.perf_counter()
         try:
             with correlation_scope():
                 if self._server_client is not None:
@@ -733,7 +744,7 @@ class Guard:
             raise
         except Exception as exc:
             _log.error("guard.scan_request failed: %s", exc)
-            return _fail_closed(exc)
+            return _fail_closed(exc, started)
 
     @property
     def is_server_mode(self) -> bool:

--- a/sdk/tests/unit/scanners/test_error_handling.py
+++ b/sdk/tests/unit/scanners/test_error_handling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Generator
 from unittest.mock import patch
 
@@ -78,3 +79,40 @@ class TestGuardFailClosed:
             result = guard.check_tool_call("rm", {"-rf": "/"})
         assert result.safe is False
         assert result.action == Action.BLOCK
+
+    def test_scan_error_is_labelled_as_the_error_stage(self):
+        guard = Guard(scanners=["injection"])
+        with patch.object(guard._input_pipeline, "run", side_effect=RuntimeError("fatal")):
+            result = guard.scan("test")
+        assert result.stages_run == ["error"]
+        assert result.findings[0].stage == "error"
+
+    def test_scan_output_error_is_labelled_as_the_error_stage(self):
+        guard = Guard(scanners=["injection"])
+        with patch.object(guard._output_pipeline, "run", side_effect=RuntimeError("fatal")):
+            result = guard.scan_output("test")
+        assert result.stages_run == ["error"]
+
+    def test_check_tool_call_error_is_labelled_as_the_error_stage(self):
+        guard = Guard(scanners=["injection"])
+        with patch.object(guard._tool_pipeline, "run", side_effect=RuntimeError("fatal")):
+            result = guard.check_tool_call("rm", {"-rf": "/"})
+        assert result.stages_run == ["error"]
+
+    def test_error_result_reports_the_time_actually_spent(self):
+        """A slow failure must not be indistinguishable from an instant block."""
+        guard = Guard(scanners=["injection"])
+
+        def slow_boom(*_args, **_kwargs):
+            time.sleep(0.02)
+            raise RuntimeError("fatal")
+
+        with patch.object(guard._input_pipeline, "run", side_effect=slow_boom):
+            result = guard.scan("test")
+        assert result.latency_ms >= 20.0
+
+    def test_fast_error_still_reports_a_real_measurement(self):
+        guard = Guard(scanners=["injection"])
+        with patch.object(guard._input_pipeline, "run", side_effect=RuntimeError("fatal")):
+            result = guard.scan("test")
+        assert result.latency_ms > 0.0


### PR DESCRIPTION
Closes #106.

`_fail_closed` returned `latency_ms=0.0` and an empty `stages_run`, so a scan blocked by a slow internal error looked exactly like one blocked instantly — in metrics and in logs. `_limit_result`, directly below it, already sets `stages_run=["limits"]`.

## What changed

```python
def _fail_closed(exc: Exception, started: float) -> ScanResult:
    ...
    latency_ms=(time.perf_counter() - started) * 1000,
    stages_run=["error"],
```

The Finding's `stage` was already `"error"`, so this is the result agreeing with its own finding rather than a new label.

All three call sites take a reading immediately before their `try` block:

| Method | Timer placement |
|---|---|
| `scan_request` | after `check_input_length` |
| `scan_output_request` | after `check_input_length` |
| `check_tool_call` | after the tool-allowed / profile / call-count checks, just before `ToolCall` runs |

In each case the early returns above are `_limit_result`, which carries its own stage, so nothing that returns before the timer needs one.

`started` is a required parameter rather than an optional one — `_fail_closed` is module-private with exactly three callers, and a default would let a future call site silently go back to reporting 0.0.

## Tests

Five assertions added to the existing `TestGuardFailClosed`, matching its style (`patch.object(guard._<x>_pipeline, "run", side_effect=RuntimeError("fatal"))`):

- `stages_run == ["error"]` on each of the three paths
- the finding's own `stage` is `"error"` on the scan path
- a pipeline that sleeps 20 ms before raising reports `latency_ms >= 20.0` — this is the one that would have caught the original bug
- a fast failure still reports `latency_ms > 0.0`

**Red-before-green:** with `git stash push -- sdk/src/unplug/guard.py`, all five fail against pristine code; with it restored, all 11 in the file pass.

Full suite on Windows / Python 3.12: `tests/unit tests/integration tests/security` — 1064 passed, 32 skipped. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)