### PR TITLE
docs(guard): state that scan_output_request ignores request.scanners (closes #105)

### DIFF
--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -617,7 +617,20 @@ class Guard:
         *,
         isolated: bool = False,
     ) -> ScanResult:
-        """Scan output from a ScanRequest (hosted server or local pipeline)."""
+        """Scan output from a ScanRequest (hosted server or local pipeline).
+
+        `request.scanners` is **not** honoured here, unlike in `scan_request`.
+        That field selects from the input scanner registry — `resolve_input_scanners`
+        unions it with `MANDATORY_INPUT_SCANNERS` — whereas the output path runs a
+        fixed `OutputPipeline` composed at construction time (secrets sanitizer,
+        leakage, secrets, urls, and pii when configured). There is no per-request
+        set to narrow, and narrowing it is not something callers should be able to
+        do: the output stage is what keeps secrets from leaving.
+
+        Passing `scanners` on an output request is therefore silently ignored
+        rather than an error, so that one `ScanRequest` can be handed to both
+        entry points. See `test_output_ignores_request_scanners`.
+        """
         violation = self._limits.check_input_length(request.text)
         if violation is not None:
             return _limit_result(violation, len(request.text))

--- a/sdk/tests/integration/test_guard_request_scanners.py
+++ b/sdk/tests/integration/test_guard_request_scanners.py
@@ -23,6 +23,51 @@ def test_per_request_scanners_do_not_stick_on_shared_session() -> None:
     assert guard.context.allowed_scanners is None
 
 
+def test_output_ignores_request_scanners() -> None:
+    """scan_output_request drops `scanners`; the output pipeline is not selectable.
+
+    Narrowing it would let a caller switch off the stage that stops secrets
+    leaving, so the same request with and without the field must scan the same.
+    """
+    leaky = "here is the key sk-ant-api03-AAAABBBBCCCCDDDDEEEEFFFF and https://bit.ly/3evil"
+
+    guard = Guard()
+    with_field = guard.scan_output_request(
+        ScanRequest(text=leaky, scanners=["secrets"], source=Source.TOOL_OUTPUT),
+        isolated=True,
+    )
+    without_field = guard.scan_output_request(
+        ScanRequest(text=leaky, source=Source.TOOL_OUTPUT),
+        isolated=True,
+    )
+
+    assert with_field.action == without_field.action
+    assert with_field.safe == without_field.safe
+    assert [f.category for f in with_field.findings] == [f.category for f in without_field.findings]
+
+
+def test_output_request_scanners_cannot_disable_a_stage() -> None:
+    """An allowlist naming only 'secrets' must not stop the url scanner running."""
+    guard = Guard()
+    result = guard.scan_output_request(
+        ScanRequest(
+            text="exfiltrate via https://bit.ly/3evil",
+            scanners=["secrets"],
+            source=Source.TOOL_OUTPUT,
+        ),
+        isolated=True,
+    )
+    assert any(f.category == "urls" for f in result.findings)
+
+
+def test_output_request_scanners_leave_no_residue_on_the_session() -> None:
+    guard = Guard()
+    guard.scan_output_request(
+        ScanRequest(text=_URL_TEXT, scanners=["secrets"], source=Source.TOOL_OUTPUT),
+    )
+    assert guard.context.allowed_scanners is None
+
+
 def test_scan_without_scanners_after_scan_with_scanners_kwarg() -> None:
     """guard.scan() after a limited scan_request must not inherit the allowlist."""
     guard = Guard()


### PR DESCRIPTION
Closes #105.

`scan_request` honours a per-request scanner allowlist; `scan_output_request` has no equivalent, so the field is silently dropped on the output path. Ignoring it is the behaviour we want — it just wasn't stated anywhere.

## Docstring

Added to `scan_output_request`, with the reason rather than just the fact:

> `request.scanners` is **not** honoured here, unlike in `scan_request`. That field selects from the input scanner registry — `resolve_input_scanners` unions it with `MANDATORY_INPUT_SCANNERS` — whereas the output path runs a fixed `OutputPipeline` composed at construction time (secrets sanitizer, leakage, secrets, urls, and pii when configured). There is no per-request set to narrow, and narrowing it is not something callers should be able to do: the output stage is what keeps secrets from leaving.

It also records why it is ignored rather than rejected: so one `ScanRequest` can be handed to both entry points.

## Tests

The issue pointed at `sdk/tests/unit/test_guard.py`, which doesn't exist. The natural home turned out to be `tests/integration/test_guard_request_scanners.py` — "Regression tests for per-request scanners= on ScanRequest" — which already pins the input-side behaviour. Three tests added there:

- `test_output_ignores_request_scanners` — the same request with and without `scanners=["secrets"]` produces the same action, `safe` flag, and finding categories.
- `test_output_request_scanners_cannot_disable_a_stage` — an allowlist naming only `secrets` does not stop the url scanner firing. This is the assertion that would fail if someone later wired the field through.
- `test_output_request_scanners_leave_no_residue_on_the_session` — matches the existing "must not stick on shared session" tests in the file.

The fixture text trips **both** output scanners, so the first test compares two non-empty results rather than two empty ones:

```
findings [('secrets', 'registered_secret:openai_key'), ('urls', 'url_shortener')]
```

## Checks

Windows / Python 3.12: `uv run pytest tests/unit tests/integration tests/security` — 1062 passed, 32 skipped. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)