### PR TITLE
ci: cancel superseded runs with a concurrency group (closes #108)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [dev, main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/integrations-live.yml
+++ b/.github/workflows/integrations-live.yml
@@ -18,6 +18,12 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
 
+# Superseded PR runs are cancelled; nightly and manual runs are left to finish,
+# because a cancelled nightly leaves no live-integration signal for that day.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-scan.yml
+++ b/.github/workflows/pr-scan.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -9,6 +9,12 @@ on:
     types: [published]
   workflow_dispatch:
 
+# Never cancel a publish in progress: a release killed between the build and the
+# upload is worse than a stale one finishing.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Closes #108.

No workflow set a `concurrency` group, so every push to a branch started a fresh run and left the previous one going.

## Per workflow

| Workflow | `cancel-in-progress` | Why |
|---|---|---|
| `ci.yml` | `true` | The case from the issue — a three-version matrix where 3.11 and 3.12 install with `uv sync --all-extras --dev`. |
| `pr-scan.yml` | `true` | PR-only, cheap, nothing to preserve. |
| `integrations-live.yml` | `${{ github.event_name == 'pull_request' }}` | See below. |
| `publish-pypi.yml` | `false` | Grouped but never cancelled, as the issue asks. |
| `reusable-agent-scan.yml` | *(not touched)* | See below. |

**`integrations-live.yml`** also runs on a 06:00 cron and `workflow_dispatch`. Scheduled runs carry `github.ref` of the default branch, so a flat `cancel-in-progress: true` would let a manual dispatch kill that morning's nightly — and a cancelled nightly leaves no live-integration signal for the day. Cancelling only on `pull_request` gets the benefit where the superseding actually happens.

**`reusable-agent-scan.yml`** is `workflow_call`-only with no in-repo caller. `concurrency` in a reusable workflow evaluates in the *caller's* context, so a group there would start cancelling runs in downstream consumers' repos rather than ours. Deliberately left alone — happy to add it if you'd rather it were there.

## Verification

No test covers this, as the issue notes. What I could check locally: all five files re-parsed with `yaml.safe_load`, confirming each block lands at the **top level** of the workflow and not nested inside `on:` — the easy way to get this wrong, since it's silently ignored there.

```
ci.yml                       concurrency={'group': '${{ github.workflow }}-${{ github.ref }}', 'cancel-in-progress': True}
integrations-live.yml        concurrency={'group': '...', 'cancel-in-progress': "${{ github.event_name == 'pull_request' }}"}
pr-scan.yml                  concurrency={'group': '...', 'cancel-in-progress': True}
publish-pypi.yml             concurrency={'group': '...', 'cancel-in-progress': False}
reusable-agent-scan.yml      concurrency=None
```

The real check is the one you describe — a second push to this PR should cancel the first CI run — and that can only be observed once this is on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)