### PR TITLE
Document how to claim an issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@
 
 ## Checklist
 
+- [ ] The issue this closes was assigned to me (see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
+- [ ] This is my only open PR, or my first PR has already been merged
 - [ ] Target branch is `dev` (see [BRANCHING.md](BRANCHING.md))
 - [ ] `cd sdk && make check-ci` passes locally
 - [ ] New code has tests (every module gets a test file)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,27 @@ Integration guides: [`sdk/integrations/README.md`](sdk/integrations/README.md). 
 
 4. Verify your environment: `make check` (lint + format + tests).
 
+## Claiming an issue
+
+Comment on the issue saying you want it, and wait for a maintainer to assign it
+to you. Assignment usually happens within a day.
+
+Do not start writing code before the issue is assigned. It is the only way we can
+stop two people building the same thing, and we would rather tell you an issue is
+already spoken for than have you find out at review time.
+
+Keep one open PR at a time until your first one is merged. After that, take as
+many as you like.
+
+If an issue is already assigned, leave it alone, even if it has been quiet for a
+while. Ask on the issue if you think something has stalled.
+
+Maintainers assign issues to themselves directly, since there is nobody for them
+to collide with.
+
+If you go quiet for a couple of weeks we will ask whether you are still on it
+before freeing it up. We will always ask you first.
+
 ## Branching and PRs
 
 - Do **not** push directly to `main`.


### PR DESCRIPTION
Adds a "Claiming an issue" section to CONTRIBUTING.md and two checkboxes to the PR template.

The rule already existed on every `good first issue` filed so far, which said to comment and wait for assignment. It was not written anywhere a contributor would read before starting, so the only way to learn it was to have a PR closed.

Two things it states that were not written down anywhere:

- Wait for the assignment before writing code. Assignment usually happens within a day.
- One open PR at a time until the first one is merged.

The PR template gets matching checkboxes, since the tracker is not where people look right before opening a PR.

No promise on review turnaround, only on assignment, and "usually" rather than a guarantee.
