### PR TITLE
guard: collapse duplicate ml-degraded warning into one helper

### DIFF
--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -199,15 +199,7 @@ class Guard:
                         f"require_ml=true but model tier {tier!r} could not be loaded: "
                         f"{type(exc).__name__}: {exc}"
                     ) from exc
-                _log.warning(
-                    "active_model=%s configured but injection_ml failed to load (%s). "
-                    'Fix: pip install "unplug-ai[ml]", then unplug-models download %s '
-                    "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only.",
-                    cfg.active_model,
-                    type(exc).__name__,
-                    cfg.active_model,
-                )
-                self._ml_degraded = True
+                self._warn_ml_degraded(cfg.active_model, exc)
             if provider is not None and spec is not None:
                 self._ml_provider = provider
                 self._model_cache_version = model_cache_version(spec)
@@ -217,14 +209,7 @@ class Guard:
                     f"Run: unplug-models download {cfg.active_model}"
                 )
             elif load_error is None:
-                _log.warning(
-                    "active_model=%s configured but injection_ml is not loaded. "
-                    'Fix: pip install "unplug-ai[ml]", then unplug-models download %s '
-                    "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only.",
-                    cfg.active_model,
-                    cfg.active_model,
-                )
-                self._ml_degraded = True
+                self._warn_ml_degraded(cfg.active_model)
 
         v2_scanners = self._registry.get_many(scanner_names, configs=cfg.scanner_configs)
         if self._ml_provider is not None:
@@ -278,6 +263,23 @@ class Guard:
             trajectory_config=cfg.trajectory,
             degradation_config=cfg.degradation,
         )
+
+    def _warn_ml_degraded(self, active_model: str, exc: Exception | None = None) -> None:
+        """Log the active_model/ML-not-loaded warning once and mark ML degraded.
+
+        ``exc`` is the load failure when one was caught; omitted when the
+        model simply never got wired up (no failure to report).
+        """
+        detail = f"failed to load ({type(exc).__name__})" if exc is not None else "is not loaded"
+        _log.warning(
+            "active_model=%s configured but injection_ml %s. "
+            'Fix: pip install "unplug-ai[ml]", then unplug-models download %s '
+            "(or set UNPLUG_MODEL_PATH). Continuing with regex scanners only.",
+            active_model,
+            detail,
+            active_model,
+        )
+        self._ml_degraded = True
 
     @property
     def context(self) -> ExecutionContext:


### PR DESCRIPTION
Collapses the two near-identical "active_model configured but ML not loaded" warnings in Guard.__init__ into one helper, _warn_ml_degraded(self, active_model, exc=None). Both call sites now go through it — one message site instead of two, same log text, same self._ml_degraded = True behavior. No logic changes.

Verified the formatted output matches the original messages exactly in both the exception and no-exception cases.

Testing: uv run pytest tests/unit -k ml — 75 passed, 11 skipped (pre-existing, unrelated), 0 failed.

Closes #104 
