### PR TITLE
Contributor docs, docs site, and triage automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Something in the SDK doesn't work as documented
-labels: ["bug"]
+labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,9 @@ contact_links:
   - name: Security vulnerability
     url: https://github.com/UnplugAI/Unplug/security/advisories/new
     about: Report security issues privately — never in a public issue.
+  - name: Question about using Unplug
+    url: https://github.com/UnplugAI/Unplug/discussions/categories/q-a
+    about: How do I scan X, why did this get blocked, does it work with Y. Ask in Q&A.
+  - name: Idea or feedback
+    url: https://github.com/UnplugAI/Unplug/discussions/categories/ideas
+    about: Half-formed ideas welcome. Issues are for things we have agreed to build.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,38 @@
+name: Documentation problem
+description: Something in the docs is wrong, missing, or out of date.
+labels: ["documentation", "needs-triage"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Where
+      description: File path or URL. A line number helps.
+      placeholder: sdk/docs/GETTING_STARTED.md, or README.md:60
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong
+      description: >
+        Quote the text if it is short. If the docs describe an API that does not
+        exist any more, paste the error you got when you followed them.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What it should say
+      description: A rough draft is fine. We are not expecting finished prose.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: offer
+    attributes:
+      label: Fixing it
+      options:
+        - label: I would like to fix this myself (a maintainer will assign it to you)
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest a new scanner, integration, or SDK capability
-labels: ["enhancement"]
+labels: ["enhancement", "needs-triage"]
 body:
   - type: textarea
     id: problem

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@
 - [ ] New code has tests (every module gets a test file)
 - [ ] Public API changes are reflected in `sdk/README.md` / `sdk/docs/`
 - [ ] No secrets, internal URLs, or private paths in the diff
+- [ ] If a model wrote a meaningful part of this, I said so below ([AI_POLICY.md](../AI_POLICY.md))
 
 ## Notes for reviewers
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ## Checklist
 
 - [ ] The issue this closes was assigned to me (see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
-- [ ] This is my only open PR, or my first PR has already been merged
+- [ ] This is my only open PR (one issue at a time, see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
 - [ ] Target branch is `dev` (see [BRANCHING.md](BRANCHING.md))
 - [ ] `cd sdk && make check-ci` passes locally
 - [ ] New code has tests (every module gets a test file)

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,24 @@
+# Auto-labels PRs by what they touch. Reuses the existing issue labels rather than
+# inventing PR-only ones, so filtering by `documentation` finds both.
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "sdk/docs/**"
+          - "mkdocs.yml"
+          - "docs-requirements.txt"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "sdk/pyproject.toml"
+          - "sdk/uv.lock"
+          - ".pre-commit-config.yaml"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/actions/**"
+          - "Makefile"
+          - "sdk/Makefile"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
       # point of running this on PRs.
       - run: mkdocs build --strict
 
-      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         if: github.ref == 'refs/heads/dev' && github.event_name != 'pull_request'
         with:
           path: site
@@ -56,4 +56,4 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+name: Docs
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "sdk/docs/**"
+      - "mkdocs.yml"
+      - "docs-requirements.txt"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "sdk/docs/**"
+      - "mkdocs.yml"
+      - "docs-requirements.txt"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - run: pip install -r docs-requirements.txt
+
+      # --strict fails the build on a broken internal link, which is the whole
+      # point of running this on PRs.
+      - run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        if: github.ref == 'refs/heads/dev' && github.event_name != 'pull_request'
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/dev' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,17 @@
+name: Label
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          sync-labels: true

--- a/.github/workflows/stale-claims.yml
+++ b/.github/workflows/stale-claims.yml
@@ -37,8 +37,9 @@ jobs:
           nudge_cutoff=$(( now - NUDGE_DAYS * 86400 ))
           free_cutoff=$(( now - FREE_DAYS * 86400 ))
 
+          limit=1000
           gh issue list --repo "$REPO" --state open --label claimed \
-            --limit 200 --json number,updatedAt,assignees,labels > issues.json
+            --limit "$limit" --json number,updatedAt,assignees,labels > issues.json
 
           # Read into an array first. A `while read` over a pipe runs in a subshell,
           # which makes failures inside it easy to lose.
@@ -48,6 +49,11 @@ jobs:
           if [ "${#rows[@]:-0}" -eq 0 ]; then
             echo "nothing to sweep"
             exit 0
+          fi
+          # Never truncate quietly. If we ever hit the cap, the oldest claims are the
+          # ones dropped, and those are exactly the ones this job exists to catch.
+          if [ "${#rows[@]}" -ge "$limit" ]; then
+            echo "::warning::Hit the $limit issue cap. Older claims were not swept; paginate this query."
           fi
 
           for row in "${rows[@]}"; do

--- a/.github/workflows/stale-claims.yml
+++ b/.github/workflows/stale-claims.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "0 6 * * 1" # Mondays, 06:00 UTC
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log what would happen without commenting or unassigning"
+        type: boolean
+        default: false
 
 permissions:
   issues: write
@@ -21,6 +26,7 @@ jobs:
       MAINTAINERS: chiruu12
       NUDGE_DAYS: "21"
       FREE_DAYS: "7"
+      DRY_RUN: ${{ inputs.dry_run }}
     steps:
       - name: Nudge or free claimed issues
         shell: bash
@@ -34,43 +40,64 @@ jobs:
           gh issue list --repo "$REPO" --state open --label claimed \
             --limit 200 --json number,updatedAt,assignees,labels > issues.json
 
-          jq -c '.[]' issues.json | while read -r issue; do
-            number=$(jq -r '.number' <<<"$issue")
-            updated=$(date -u -d "$(jq -r '.updatedAt' <<<"$issue")" +%s)
-            assignees=$(jq -r '[.assignees[].login] | join(" ")' <<<"$issue")
-            is_stale=$(jq -r '[.labels[].name] | index("stale") != null' <<<"$issue")
+          # Read into an array first. A `while read` over a pipe runs in a subshell,
+          # which makes failures inside it easy to lose.
+          rows=()
+          while IFS= read -r line; do rows+=("$line"); done < <(jq -c '.[]' issues.json)
+          echo "claimed issues: ${#rows[@]:-0}"
+          if [ "${#rows[@]:-0}" -eq 0 ]; then
+            echo "nothing to sweep"
+            exit 0
+          fi
 
-            [ -z "$assignees" ] && continue
+          for row in "${rows[@]}"; do
+            number=$(jq -r '.number' <<<"$row")
+            updated=$(date -u -d "$(jq -r '.updatedAt' <<<"$row")" +%s)
+            assignees=$(jq -r '[.assignees[].login] | join(" ")' <<<"$row")
+            is_stale=$(jq -r '[.labels[].name] | index("stale") != null' <<<"$row")
 
-            # Skip if every assignee is a maintainer.
-            others=""
+            if [ -z "$assignees" ]; then
+              echo "#$number: claimed but unassigned, skipping"
+              continue
+            fi
+
+            # Drop maintainers from the list; skip the issue if nobody else is on it.
+            others=()
             for a in $assignees; do
               case " $MAINTAINERS " in
                 *" $a "*) ;;
-                *) others="$others $a" ;;
+                *) others+=("$a") ;;
               esac
             done
-            [ -z "${others// /}" ] && continue
+            if [ "${#others[@]}" -eq 0 ]; then
+              echo "#$number: maintainer-assigned, exempt"
+              continue
+            fi
 
-            mentions=$(for a in $others; do printf '@%s ' "$a"; done)
+            mentions=""
+            for a in "${others[@]}"; do mentions+="@$a "; done
 
             if [ "$is_stale" = "true" ] && [ "$updated" -lt "$free_cutoff" ]; then
-              echo "freeing #$number"
-              gh issue comment "$number" --repo "$REPO" --body \
-          "Freeing this up so someone else can take it. No hard feelings, and if you
-          were mid-way through, say so and it is yours again."
-              for a in $others; do
+              echo "#$number: freeing (assigned to ${others[*]})"
+              [ "${DRY_RUN:-false}" = "true" ] && continue
+
+              # Single-line body. Indented continuation lines would land in the
+              # comment verbatim and markdown would render them as a code block.
+              gh issue comment "$number" --repo "$REPO" --body "Freeing this up so someone else can take it. No hard feelings, and if you were mid-way through, say so and it is yours again."
+              for a in "${others[@]}"; do
                 gh issue edit "$number" --repo "$REPO" --remove-assignee "$a"
               done
               gh issue edit "$number" --repo "$REPO" \
                 --remove-label claimed --remove-label stale --add-label "help wanted"
 
             elif [ "$is_stale" != "true" ] && [ "$updated" -lt "$nudge_cutoff" ]; then
-              echo "nudging #$number"
-              gh issue comment "$number" --repo "$REPO" --body \
-          "${mentions}still on this one? No rush and no pressure to say yes. If we do not
-          hear back in a week we will unassign it so it does not sit blocked, and you
-          can pick it straight back up whenever you want."
+              echo "#$number: nudging (assigned to ${others[*]})"
+              [ "${DRY_RUN:-false}" = "true" ] && continue
+
+              gh issue comment "$number" --repo "$REPO" --body "${mentions}still on this one? No rush and no pressure to say yes. If we do not hear back in a week we will unassign it so it does not sit blocked, and you can pick it straight back up whenever you want."
               gh issue edit "$number" --repo "$REPO" --add-label stale
+
+            else
+              echo "#$number: active, leaving alone"
             fi
           done

--- a/.github/workflows/stale-claims.yml
+++ b/.github/workflows/stale-claims.yml
@@ -1,0 +1,76 @@
+name: Stale claims
+
+# CONTRIBUTING.md promises we ask before freeing an issue up. This is that promise,
+# automated: a nudge at 21 days of silence, unassignment 7 days after the nudge.
+# Maintainers are exempt (nobody is waiting on their issue).
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays, 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      MAINTAINERS: chiruu12
+      NUDGE_DAYS: "21"
+      FREE_DAYS: "7"
+    steps:
+      - name: Nudge or free claimed issues
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          now=$(date -u +%s)
+          nudge_cutoff=$(( now - NUDGE_DAYS * 86400 ))
+          free_cutoff=$(( now - FREE_DAYS * 86400 ))
+
+          gh issue list --repo "$REPO" --state open --label claimed \
+            --limit 200 --json number,updatedAt,assignees,labels > issues.json
+
+          jq -c '.[]' issues.json | while read -r issue; do
+            number=$(jq -r '.number' <<<"$issue")
+            updated=$(date -u -d "$(jq -r '.updatedAt' <<<"$issue")" +%s)
+            assignees=$(jq -r '[.assignees[].login] | join(" ")' <<<"$issue")
+            is_stale=$(jq -r '[.labels[].name] | index("stale") != null' <<<"$issue")
+
+            [ -z "$assignees" ] && continue
+
+            # Skip if every assignee is a maintainer.
+            others=""
+            for a in $assignees; do
+              case " $MAINTAINERS " in
+                *" $a "*) ;;
+                *) others="$others $a" ;;
+              esac
+            done
+            [ -z "${others// /}" ] && continue
+
+            mentions=$(for a in $others; do printf '@%s ' "$a"; done)
+
+            if [ "$is_stale" = "true" ] && [ "$updated" -lt "$free_cutoff" ]; then
+              echo "freeing #$number"
+              gh issue comment "$number" --repo "$REPO" --body \
+          "Freeing this up so someone else can take it. No hard feelings, and if you
+          were mid-way through, say so and it is yours again."
+              for a in $others; do
+                gh issue edit "$number" --repo "$REPO" --remove-assignee "$a"
+              done
+              gh issue edit "$number" --repo "$REPO" \
+                --remove-label claimed --remove-label stale --add-label "help wanted"
+
+            elif [ "$is_stale" != "true" ] && [ "$updated" -lt "$nudge_cutoff" ]; then
+              echo "nudging #$number"
+              gh issue comment "$number" --repo "$REPO" --body \
+          "${mentions}still on this one? No rush and no pressure to say yes. If we do not
+          hear back in a week we will unassign it so it does not sit blocked, and you
+          can pick it straight back up whenever you want."
+              gh issue edit "$number" --repo "$REPO" --add-label stale
+            fi
+          done

--- a/.github/workflows/stale-claims.yml
+++ b/.github/workflows/stale-claims.yml
@@ -37,30 +37,32 @@ jobs:
           nudge_cutoff=$(( now - NUDGE_DAYS * 86400 ))
           free_cutoff=$(( now - FREE_DAYS * 86400 ))
 
-          limit=1000
-          gh issue list --repo "$REPO" --state open --label claimed \
-            --limit "$limit" --json number,updatedAt,assignees,labels > issues.json
+          # Fully paginated: no cap, so no claim can age out of the sweep. The REST
+          # issues endpoint also returns PRs, hence the pull_request filter. One JSON
+          # object per line.
+          gh api --paginate \
+            "repos/$REPO/issues?state=open&labels=claimed&per_page=100" \
+            --jq '.[]
+                  | select(.pull_request == null)
+                  | {number, updatedAt: .updated_at,
+                     assignees: [.assignees[].login],
+                     labels: [.labels[].name]}' > issues.jsonl
 
           # Read into an array first. A `while read` over a pipe runs in a subshell,
           # which makes failures inside it easy to lose.
           rows=()
-          while IFS= read -r line; do rows+=("$line"); done < <(jq -c '.[]' issues.json)
+          while IFS= read -r line; do rows+=("$line"); done < issues.jsonl
           echo "claimed issues: ${#rows[@]:-0}"
           if [ "${#rows[@]:-0}" -eq 0 ]; then
             echo "nothing to sweep"
             exit 0
           fi
-          # Never truncate quietly. If we ever hit the cap, the oldest claims are the
-          # ones dropped, and those are exactly the ones this job exists to catch.
-          if [ "${#rows[@]}" -ge "$limit" ]; then
-            echo "::warning::Hit the $limit issue cap. Older claims were not swept; paginate this query."
-          fi
 
           for row in "${rows[@]}"; do
             number=$(jq -r '.number' <<<"$row")
             updated=$(date -u -d "$(jq -r '.updatedAt' <<<"$row")" +%s)
-            assignees=$(jq -r '[.assignees[].login] | join(" ")' <<<"$row")
-            is_stale=$(jq -r '[.labels[].name] | index("stale") != null' <<<"$row")
+            assignees=$(jq -r '.assignees | join(" ")' <<<"$row")
+            is_stale=$(jq -r '.labels | index("stale") != null' <<<"$row")
 
             if [ -z "$assignees" ]; then
               echo "#$number: claimed but unassigned, skipping"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 name: Triage
 
 # Issue forms apply needs-triage themselves. Blank issues do not, and those are the
-# ones most likely to get lost.
+# ones most likely to get lost. Anything a maintainer opens is triaged by definition.
 
 on:
   issues:
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   label:
+    if: >
+      !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+      github.event.issue.author_association)
     runs-on: ubuntu-latest
     steps:
       - name: Add needs-triage
@@ -20,16 +23,3 @@ jobs:
         run: |
           gh issue edit "${{ github.event.issue.number }}" \
             --repo "${{ github.repository }}" --add-label needs-triage
-
-  clear:
-    # Anything a maintainer opens is already triaged by definition.
-    if: contains(fromJSON('["OWNER","MEMBER"]'), github.event.issue.author_association)
-    needs: label
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove needs-triage
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh issue edit "${{ github.event.issue.number }}" \
-            --repo "${{ github.repository }}" --remove-label needs-triage

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,35 @@
+name: Triage
+
+# Issue forms apply needs-triage themselves. Blank issues do not, and those are the
+# ones most likely to get lost.
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add needs-triage
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" --add-label needs-triage
+
+  clear:
+    # Anything a maintainer opens is already triaged by definition.
+    if: contains(fromJSON('["OWNER","MEMBER"]'), github.event.issue.author_association)
+    needs: label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove needs-triage
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" --remove-label needs-triage

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -2,6 +2,9 @@ name: Triage
 
 # Issue forms apply needs-triage themselves. Blank issues do not, and those are the
 # ones most likely to get lost. Anything a maintainer opens is triaged by definition.
+#
+# COLLABORATOR is deliberately not exempt. Contributors get write access here so they
+# can push branches, which is not the same as their issues arriving pre-triaged.
 
 on:
   issues:
@@ -13,7 +16,7 @@ permissions:
 jobs:
   label:
     if: >
-      !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+      !contains(fromJSON('["OWNER","MEMBER"]'),
       github.event.issue.author_association)
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -206,9 +206,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   and can be added to the global gitignore or merged into this file. However, if you prefer,
 #   you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 # Temporary file for partial code execution

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,9 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    # Keep in step with the ruff pinned in sdk/pyproject.toml. If these drift, the
+    # hook passes locally and CI fails, which is worse than having no hook.
+    rev: v0.15.13
     hooks:
       # Ruff resolves sdk/pyproject.toml by walking up from each file.
       - id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# Install once:  uv tool install pre-commit && pre-commit install
+# Run manually:  pre-commit run --all-files
+#
+# These hooks are the fast half of `make check`. They will not catch mypy or
+# test failures, so run `cd sdk && make check-ci` before opening a PR.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: ^sdk/tests/.*/fixtures/
+      - id: end-of-file-fixer
+        exclude: ^sdk/tests/.*/fixtures/
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=512]
+      - id: detect-private-key
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.2
+    hooks:
+      # Ruff resolves sdk/pyproject.toml by walking up from each file.
+      - id: ruff-check
+        args: [--fix]
+        files: ^sdk/
+      - id: ruff-format
+        files: ^sdk/

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,49 @@
+# Using AI to contribute
+
+We build AI security tooling. We are not going to pretend nobody uses a model.
+
+## The rule
+
+If a model wrote a meaningful part of your patch, say so in the PR description.
+One line is enough. "Drafted with Claude Code, I reviewed and tested it" covers it.
+
+Undisclosed AI-generated PRs get closed. Not because the code is bad. Because we
+cannot review what you cannot explain, and finding that out three review rounds in
+wastes your time more than ours.
+
+Disclosed or not, the bar is identical:
+
+- You ran `cd sdk && make check-ci` and it passed.
+- You can answer questions about the diff without going back to the model.
+- The change does what the issue asked for, and nothing else.
+
+Meet those and we do not care how the characters got into the file.
+
+## What gets closed on sight
+
+- A PR body that describes the journey rather than the change. We do not need to
+  know what you tried first.
+- Rewrites of files the issue did not mention.
+- Invented benchmark numbers, or claims about detection rates that no test backs up.
+  This is a security repo. A confident wrong number is worse here than in most places.
+- Tests that assert the implementation instead of the behaviour, added only to make
+  a coverage gate pass.
+
+## If you are driving an agent
+
+Point it at the issue, `CONTRIBUTING.md`, and the tests that already cover the area.
+Make it run `make check-ci` before it writes the PR body, not after. Most of the
+agent PRs we close fail because the agent never ran anything, not because it wrote
+bad Python.
+
+Read the diff yourself before you open it. If there is a hunk in there you would
+not defend in review, take it out.
+
+## Why we bother saying this
+
+Prompt injection research is downstream of trusting what text claims about itself.
+A repo that cannot tell which of its patches were understood by a human has the
+same problem its own SDK is meant to solve. We would rather be blunt about it early.
+
+Questions about this policy go in
+[Discussions](https://github.com/UnplugAI/Unplug/discussions/categories/q-a).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,12 @@ Do not start writing code before the issue is assigned. It is the only way we ca
 stop two people building the same thing, and we would rather tell you an issue is
 already spoken for than have you find out at review time.
 
-Keep one open PR at a time until your first one is merged. After that, take as
-many as you like.
+One issue at a time. When the PR for it is merged, we assign you the next one.
+
+That is not a judgement on how fast you work. An assigned issue looks taken to
+everyone else, so two parked issues means two people who could have picked
+something up and did not. Ask for the next one whenever you like and we will
+queue it against your name.
 
 If an issue is already assigned, leave it alone, even if it has been quiet for a
 while. Ask on the issue if you think something has stalled.
@@ -86,8 +90,8 @@ What that means in practice:
 - Getting it wrong first try is expected. Nobody's first patch to a security scanner
   is right.
 
-Mentored issues do not count against the one-open-PR limit, so you can take one while
-another PR of yours is in review.
+A mentored issue is still one issue. The one-at-a-time rule above applies here too,
+and we would rather you finish this one with help than juggle two.
 
 Two things we ask in return. Tell us when you get stuck rather than disappearing, and
 write the patch yourself. Reading an explanation is the point of the label. If a model

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,39 @@ to collide with.
 If you go quiet for a couple of weeks we will ask whether you are still on it
 before freeing it up. We will always ask you first.
 
+## Mentored issues
+
+Issues labelled [`mentored`](https://github.com/UnplugAI/Unplug/labels/mentored)
+come with a maintainer attached. They are for people who want to learn the codebase,
+not just people who already know it.
+
+What that means in practice:
+
+- The issue tells you which file to open and which test should exist when you are done.
+- Ask anything on the issue thread. "I do not understand what taint propagation is
+  for" is a fine question. So is "I have been stuck on this import error for an hour".
+- We will review a half-finished PR if you want a check on direction. Open it as a
+  draft and say what you are unsure about.
+- Getting it wrong first try is expected. Nobody's first patch to a security scanner
+  is right.
+
+Mentored issues do not count against the one-open-PR limit, so you can take one while
+another PR of yours is in review.
+
+Two things we ask in return. Tell us when you get stuck rather than disappearing, and
+write the patch yourself. Reading an explanation is the point of the label. If a model
+writes it for you there is nothing left to learn, and [AI_POLICY.md](AI_POLICY.md)
+applies here the same as anywhere else.
+
+If you want a mentored issue but none are open, say so in
+[Discussions](https://github.com/UnplugAI/Unplug/discussions/categories/q-a) and we
+will label one.
+
+## Using AI to write your patch
+
+Allowed, and you have to disclose it. Undisclosed AI-generated PRs get closed.
+Full policy: [AI_POLICY.md](AI_POLICY.md).
+
 ## Branching and PRs
 
 - Do **not** push directly to `main`.
@@ -98,6 +131,16 @@ GitHub Actions runs on every PR to `dev` ([`.github/workflows/ci.yml`](.github/w
 5. **Coverage** — SDK coverage report with an 80% minimum gate (`make test-cov`)
 
 ## Local checks (SDK)
+
+Install the hooks once and ruff stops being a CI failure:
+
+```bash
+uv tool install pre-commit
+pre-commit install
+```
+
+The hooks are the fast half of `make check`. They do not run mypy or the test suite,
+so still run `make check-ci` before you open the PR.
 
 ```bash
 cd sdk

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,9 @@ make check
 # Exact CI parity before PR (includes exfil demo + security subset)
 make check-ci
 
+# Docs drift only: every `from unplug import ...` in the docs must resolve
+make check-docs
+
 # Coverage report and 80% minimum gate
 make test-cov
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Try it without installing anything: [live demo](https://huggingface.co/spaces/Un
 | ML span model `Guard.with_tiny()` | **Preview** ([unplug-tiny-v1](https://huggingface.co/Unplug-AI/unplug-tiny-v1)) |
 | Sliding-window long documents + streaming scan | **Included** |
 
-On the neuralchemy prompt-injection set, regex-only detection reaches **F1 0.56 / recall 0.39** — a fast first line, not sufficient alone. Adding the ML span model (`Guard.with_tiny()`) takes that to **F1 0.99 / recall 0.98**, and lifts recall on *indirect* injection from **0.05 → 0.91**. False-positive rate stays under 1% on the injection set (2.1% on a separate hard-benign corpus). Full tables, methodology, and honest caveats: [`sdk/docs/BENCHMARKS.md`](sdk/docs/BENCHMARKS.md). Per-axis model metrics (including failure modes) are on the [model card](https://huggingface.co/Unplug-AI/unplug-tiny-v1).
+On the neuralchemy prompt-injection set, regex-only detection reaches **F1 0.58 / recall 0.41** — a fast first line, not sufficient alone. Adding the ML span model (`Guard.with_tiny()`) takes that to **F1 0.99 / recall 0.98**, and lifts recall on *indirect* injection from **0.05 → 0.91**. False-positive rate stays under 1% on the injection set (2.1% on a separate hard-benign corpus). Full tables, methodology, and honest caveats: [`sdk/docs/BENCHMARKS.md`](sdk/docs/BENCHMARKS.md). Per-axis model metrics (including failure modes) are on the [model card](https://huggingface.co/Unplug-AI/unplug-tiny-v1).
 
 ## Agent host checklist
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Unplug is agent runtime security for LLM applications. It tracks where text came
 <p>
   <a href="https://github.com/UnplugAI/Unplug/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/UnplugAI/Unplug/actions/workflows/ci.yml/badge.svg?branch=dev"></a>
   <a href="https://pypi.org/project/unplug-ai/"><img alt="PyPI" src="https://img.shields.io/pypi/v/unplug-ai"></a>
+  <a href="https://unplugai.github.io/Unplug/"><img alt="Docs" src="https://img.shields.io/badge/Docs-unplugai.github.io-3b82f6"></a>
   <a href="https://huggingface.co/spaces/Unplug-AI/unplug-tiny-demo"><img alt="Live demo" src="https://img.shields.io/badge/Live_demo-Hugging_Face_Space-22c55e"></a>
   <a href="https://huggingface.co/Unplug-AI/unplug-tiny-v1"><img alt="Model" src="https://img.shields.io/badge/Model-unplug--tiny--v1-f59e0b"></a>
   <a href="https://www.apache.org/licenses/LICENSE-2.0"><img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-9ca3af"></a>
@@ -94,6 +95,23 @@ See [sdk/README.md](sdk/README.md) for config (`unplug.toml`), `unplug-audit`, a
 cd sdk && uv sync --all-extras --dev
 make check-ci    # lint + tests + exfil demo + security regression
 ```
+
+## Contributing
+
+Yes, and we mean it. There are
+[open issues tagged `good first issue`](https://github.com/UnplugAI/Unplug/labels/good%20first%20issue),
+each with the file to open and the failing behaviour already written down.
+
+If you are new to open source, look for
+[`mentored`](https://github.com/UnplugAI/Unplug/labels/mentored). A maintainer walks
+you through those, and asking basic questions on the thread is the point rather than
+a nuisance.
+
+Comment on an issue to claim it and wait for it to be assigned before you write code.
+That rule exists so two people do not build the same thing.
+[CONTRIBUTING.md](CONTRIBUTING.md) has the details, [SUPPORT.md](SUPPORT.md) covers
+where to ask things, and [AI_POLICY.md](AI_POLICY.md) covers using a model to write
+your patch (allowed, disclose it).
 
 ## Related repos
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,61 @@
+# Roadmap
+
+Current release: **0.6.0**. This is a direction, not a set of dates. Things move
+around. If something here matters to you, say so in
+[Discussions](https://github.com/UnplugAI/Unplug/discussions/categories/ideas) and it
+moves up.
+
+## Now
+
+**Multi-language detection.** Regex and normalization are tuned for English. Ordinary
+non-English input no longer trips the evasion path (#121), but detection recall outside
+English is untested and we should not pretend otherwise. Needs a non-English corpus
+before it needs new patterns.
+
+**Redaction correctness.** Findings that span more of the input than the actual problem
+destroy usable text. #122 and the span scoping in #121 are the same underlying issue
+showing up in two places.
+
+**Cache correctness.** The safe-prefix cache is the part of the system most likely to
+turn a detection into a miss. #116 and #125 are open.
+
+**Benchmark honesty.** The benign corpus has no hard negatives (#120), so the reported
+regex FPR of 0.000 is not measuring what a reader assumes it measures.
+
+## Next
+
+**ML model past preview.** `unplug-tiny-v1` carries the recall numbers in
+[BENCHMARKS](sdk/docs/BENCHMARKS.md) but is still labelled preview. Getting it out of
+preview means latency numbers, a quantized option, and a story for CPU-only hosts.
+
+**Streaming and long documents at scale.** Sliding-window scanning exists. It has not
+been measured against documents where the window boundary is the attack.
+
+**Framework coverage that stays true.** There are 20-odd integration extras. Keeping
+them all working as their upstreams move is a real cost, and some of them probably do
+not deserve to stay.
+
+## Later
+
+**Hosted API and MCP.** [unplug-server](https://github.com/UnplugAI/unplug-server) and
+[unplug-mcp](https://github.com/UnplugAI/unplug-mcp) exist as separate repos. Neither
+is the focus while the SDK is still moving.
+
+**Policy as configuration.** Today policy is mostly code plus `unplug.toml` knobs.
+Expressing "this tool may never be called on tainted input" declaratively is the
+obvious next shape, and we have not designed it yet.
+
+## Not planned
+
+**Being a content moderation library.** Toxicity, NSFW, and brand safety are somebody
+else's problem. Unplug is about text that is trying to change what an agent does.
+
+**Blocking as the default answer.** Span-level redaction is the point. Any feature
+whose only outcome is a boolean gets pushed back.
+
+## Where the work is
+
+Issues are the source of truth. Anything labelled
+[`good first issue`](https://github.com/UnplugAI/Unplug/labels/good%20first%20issue) or
+[`mentored`](https://github.com/UnplugAI/Unplug/labels/mentored) is genuinely available
+and genuinely wanted. See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,8 @@ preview means latency numbers, a quantized option, and a story for CPU-only host
 **Streaming and long documents at scale.** Sliding-window scanning exists. It has not
 been measured against documents where the window boundary is the attack.
 
-**Framework coverage that stays true.** There are 20-odd integration extras. Keeping
+**Framework coverage that stays true.** There are twenty integration directories under
+`sdk/integrations/`, nineteen of them behind their own extra. Keeping
 them all working as their upstreams move is a real cost, and some of them probably do
 not deserve to stay.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,44 @@
+# Getting help
+
+## I have a question about using Unplug
+
+[Discussions → Q&A](https://github.com/UnplugAI/Unplug/discussions/categories/q-a).
+
+Include the version (`pip show unplug-ai`), the code you ran, and what you got back.
+For detection questions, paste the `ScanResult`: the action, the risk score, and the
+finding IDs. Those three tell us more than a description of the behaviour will.
+
+## Something is broken
+
+[Open a bug report](https://github.com/UnplugAI/Unplug/issues/new?template=bug_report.yml).
+A snippet we can paste into a REPL is worth a lot more than a stack trace alone.
+
+## Detection is wrong
+
+False positives and false negatives are bugs, so file them as bugs. Give us the exact
+input string. If it contains anything you cannot share, a minimised version that still
+reproduces is fine.
+
+Before filing, check whether your input is non-English. Regex detection is tuned for
+English today and we track that separately, see the language note in the README.
+
+## I found a vulnerability
+
+Do not open an issue.
+[Report it privately](https://github.com/UnplugAI/Unplug/security/advisories/new).
+See [SECURITY.md](SECURITY.md).
+
+## I want to contribute
+
+[CONTRIBUTING.md](CONTRIBUTING.md), and read
+[the claiming rules](CONTRIBUTING.md#claiming-an-issue) before you write code.
+
+If you are new to open source, look for the
+[`mentored`](https://github.com/UnplugAI/Unplug/labels/mentored) label. Those issues
+come with a maintainer who will walk you through it.
+
+## Response times
+
+This is a small project. Issues and Discussions usually get a reply within a day or
+two. Security reports get looked at faster. If something has been quiet for a week,
+bump the thread. That is not rude, we probably missed it.

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,2 @@
+mkdocs==1.6.1
+mkdocs-material==9.7.7

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,75 @@
+site_name: Unplug
+site_description: Agent runtime security for LLM applications.
+site_url: https://unplugai.github.io/Unplug/
+repo_url: https://github.com/UnplugAI/Unplug
+repo_name: UnplugAI/Unplug
+edit_uri: edit/dev/sdk/docs/
+copyright: Apache 2.0
+
+docs_dir: sdk/docs
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - content.code.copy
+    - content.action.edit
+    - search.suggest
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: black
+      accent: green
+      toggle:
+        icon: material/weather-night
+        name: Dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: green
+      toggle:
+        icon: material/weather-sunny
+        name: Light mode
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+
+nav:
+  - Home: index.md
+  - Start here:
+      - Getting started: GETTING_STARTED.md
+      - Architecture: ARCHITECTURE.md
+      - Public API: PUBLIC_API.md
+  - Protecting an agent:
+      - Agent actions: AGENT_ACTIONS.md
+      - Agent flow security: AGENT_FLOW_SECURITY.md
+      - RAG defense: RAG_DEFENSE.md
+      - Hermes agent security: HERMES_AGENT_SECURITY.md
+  - Detection:
+      - Benchmarks: BENCHMARKS.md
+      - Limits and the LLM judge: LIMITS_AND_JUDGE.md
+      - ML integration: ML_INTEGRATION.md
+      - Phase C evaluation: EVAL_PHASE_C.md
+  - Running it:
+      - Deployment: DEPLOYMENT.md
+      - Integrations: INTEGRATIONS.md
+      - Testing harness: TESTING_HARNESS.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/UnplugAI/Unplug
+    - icon: fontawesome/solid/robot
+      link: https://huggingface.co/Unplug-AI/unplug-tiny-v1
+      name: unplug-tiny-v1 on Hugging Face

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint typecheck format fix check check-ci test test-cov test-security \
+.PHONY: install lint typecheck format fix check check-ci check-docs test test-cov test-security \
 	test-ml test-ml-harness test-frameworks test-frameworks-live test-all-local \
 	smoke-ml smoke-ml-hooks docker-e2e audit audit-ml scenarios attack-gate examples
 
@@ -22,7 +22,10 @@ check: lint typecheck
 	uv run ruff format --check .
 	uv run pytest -q
 
-check-ci: check
+check-docs:
+	uv run python scripts/check_doc_drift.py
+
+check-ci: check check-docs
 	uv run pytest tests/integration/test_exfil_demo_integration.py -q
 	uv run python examples/agent_exfil_demo.py
 	uv run pytest tests/security tests/integration/test_deployment_modes.py tests/unit/ml/test_ml_validation.py tests/integration/test_ml_integration.py tests/integration/test_scenario_replay.py -q

--- a/sdk/PUBLISH.md
+++ b/sdk/PUBLISH.md
@@ -14,7 +14,7 @@ Package: **`unplug-ai`** | Import: **`from unplug import Guard`**
 
 ## Publish
 
-**CI (recommended):** Actions -> **Publish to PyPI** -> Run workflow  
+**CI (recommended):** Actions -> **Publish to PyPI** -> Run workflow
 Or tag a GitHub Release: workflow runs on `release: published`.
 
 **Local:**

--- a/sdk/docs/AGENT_ACTIONS.md
+++ b/sdk/docs/AGENT_ACTIONS.md
@@ -108,4 +108,4 @@ else:
 6. `scan_agent_output` before returning to user
 7. `reset_session_taint` between users / tenants
 
-See also: [`README.md`](../README.md#protect-an-agent), [`integrations/custom-loop/README.md`](../integrations/custom-loop/README.md).
+See also: [`README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/README.md#protect-an-agent), [`integrations/custom-loop/README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/custom-loop/README.md).

--- a/sdk/docs/AGENT_FLOW_SECURITY.md
+++ b/sdk/docs/AGENT_FLOW_SECURITY.md
@@ -1,6 +1,6 @@
 # Agent flow security: Hermes Agent, OpenClaw, and Unplug SDK
 
-**Updated:** 2026-06-01  
+**Updated:** 2026-06-01
 **Scope:** Techniques for securing LLM agent *flows* (not host sandboxing). Maps external patterns to SDK hooks.
 
 **Deep dive:** [HERMES_AGENT_SECURITY.md](./HERMES_AGENT_SECURITY.md) (NousResearch/hermes-agent).

--- a/sdk/docs/ARCHITECTURE.md
+++ b/sdk/docs/ARCHITECTURE.md
@@ -83,5 +83,6 @@ Everything else: submodule imports (`from unplug.scanners.injection import Injec
 
 ## Related docs
 
-- [RESTRUCTURE_PLAN.md](RESTRUCTURE_PLAN.md): migration checklist
-- [LOGIC_AUDIT.md](LOGIC_AUDIT.md): correctness review backlog
+- [PUBLIC_API.md](PUBLIC_API.md): what is importable and what is internal
+- [AGENT_FLOW_SECURITY.md](AGENT_FLOW_SECURITY.md): how taint moves through an agent loop
+- [TESTING_HARNESS.md](TESTING_HARNESS.md): which suite covers which layer

--- a/sdk/docs/BENCHMARKS.md
+++ b/sdk/docs/BENCHMARKS.md
@@ -73,9 +73,9 @@ PRs to `dev` run:
 
 | Workflow | Purpose |
 |----------|---------|
-| [`ci.yml`](../../.github/workflows/ci.yml) | Lint + mypy + pytest matrix (3.11–3.13) + attack-harness gate |
-| [`pr-scan.yml`](../../.github/workflows/pr-scan.yml) | Regex scan on changed agent/MCP config files |
-| [`reusable-agent-scan.yml`](../../.github/workflows/reusable-agent-scan.yml) | `workflow_call` entry for other repos |
+| [`ci.yml`](https://github.com/UnplugAI/Unplug/blob/dev/.github/workflows/ci.yml) | Lint + mypy + pytest matrix (3.11–3.13) + attack-harness gate |
+| [`pr-scan.yml`](https://github.com/UnplugAI/Unplug/blob/dev/.github/workflows/pr-scan.yml) | Regex scan on changed agent/MCP config files |
+| [`reusable-agent-scan.yml`](https://github.com/UnplugAI/Unplug/blob/dev/.github/workflows/reusable-agent-scan.yml) | `workflow_call` entry for other repos |
 
 The attack-harness gate (`benchmarks/attacks/ci_gate.py`) enforces per-category recall
 floors on the committed garak corpus and a benign false-positive ceiling.

--- a/sdk/docs/BENCHMARKS.md
+++ b/sdk/docs/BENCHMARKS.md
@@ -1,12 +1,12 @@
 # SDK benchmark results
 
-Date: 2026-06-15 (ML rows); regex-only neuralchemy refreshed **2026-07-20** (Phase C)
-Guard: `unplug-ai`, default scanners
-Model: `unplug-tiny-v1` (DeBERTa-v3-xsmall dual-head span model), `Guard(model="tiny")`
-Detection threshold: risk ≥ 0.5 counts as flagged (block or review)
-Methodology: **isolated single-turn sessions** — each sample is scanned in a fresh
-`ExecutionContext` (`scan_request(..., isolated=True)`), so multi-turn trajectory
-state never leaks between independent samples.
+- **Date:** 2026-06-15 (ML rows); regex-only neuralchemy refreshed **2026-07-20** (Phase C)
+- **Guard:** `unplug-ai`, default scanners
+- **Model:** `unplug-tiny-v1` (DeBERTa-v3-xsmall dual-head span model), `Guard(model="tiny")`
+- **Detection threshold:** risk ≥ 0.5 counts as flagged (block or review)
+- **Methodology:** isolated single-turn sessions. Each sample is scanned in a fresh
+  `ExecutionContext` (`scan_request(..., isolated=True)`), so multi-turn trajectory
+  state never leaks between independent samples.
 
 Phase C gap notes and download commands: [`EVAL_PHASE_C.md`](EVAL_PHASE_C.md).
 

--- a/sdk/docs/DEPLOYMENT.md
+++ b/sdk/docs/DEPLOYMENT.md
@@ -119,6 +119,6 @@ Use `unplug-sidecar doctor` to verify the sidecar is reachable before starting a
 
 ## Related
 
-- [`examples/hosted_client.py`](../examples/hosted_client.py): hosted API key flow
-- [`examples/local_sidecar_client.py`](../examples/local_sidecar_client.py): localhost server flow
-- [`repos/unplug-server`](../../../repos/unplug-server): server source and `docker-compose.sidecar.yml`
+- [`examples/hosted_client.py`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/examples/hosted_client.py): hosted API key flow
+- [`examples/local_sidecar_client.py`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/examples/local_sidecar_client.py): localhost server flow
+- [`repos/unplug-server`](https://github.com/UnplugAI/unplug-server): server source and `docker-compose.sidecar.yml`

--- a/sdk/docs/GETTING_STARTED.md
+++ b/sdk/docs/GETTING_STARTED.md
@@ -95,10 +95,10 @@ python -c "from unplug import Guard; print(Guard().scan('hello', source='user').
 
 | Goal | Doc |
 |------|-----|
-| Wire Unplug into **your** agent loop | [`integrations/custom-loop/README.md`](../integrations/custom-loop/README.md) |
-| LangGraph, CrewAI, OpenAI Agents, … | [`integrations/README.md`](../integrations/README.md) |
+| Wire Unplug into **your** agent loop | [`integrations/custom-loop/README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/custom-loop/README.md) |
+| LangGraph, CrewAI, OpenAI Agents, … | [`integrations/README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/README.md) |
 | **REVIEW** vs **BLOCK** (human approval) | [`docs/AGENT_ACTIONS.md`](AGENT_ACTIONS.md) |
-| Full SDK reference | [`README.md`](../README.md) |
+| Full SDK reference | [`README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/README.md) |
 | Hosted API / sidecar | [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) |
 
 ## Common mistakes

--- a/sdk/docs/HERMES_AGENT_SECURITY.md
+++ b/sdk/docs/HERMES_AGENT_SECURITY.md
@@ -1,6 +1,6 @@
 # Hermes Agent security: mapping to Unplug SDK
 
-**Agent:** [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) (coding agent with skills, cron, terminal tools).  
+**Agent:** [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) (coding agent with skills, cron, terminal tools).
 **Not:** the jailbreak persona "you are Hermes, unrestricted" (that is a separate `named_persona_hermes` injection pattern).
 
 ---

--- a/sdk/docs/INTEGRATIONS.md
+++ b/sdk/docs/INTEGRATIONS.md
@@ -1,6 +1,6 @@
 # Agent framework integrations
 
-> **Full guides:** [`integrations/README.md`](../integrations/README.md) — per-framework wiring, extras, and the [72-angle security matrix](../integrations/TESTING.md).
+> **Full guides:** [`integrations/README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/README.md) — per-framework wiring, extras, and the [72-angle security matrix](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/TESTING.md).
 >
 > **Beginners:** [`GETTING_STARTED.md`](GETTING_STARTED.md) · **REVIEW vs BLOCK:** [`AGENT_ACTIONS.md`](AGENT_ACTIONS.md)
 
@@ -100,7 +100,7 @@ Tool enforcement always runs locally. See [`DEPLOYMENT.md`](DEPLOYMENT.md).
 uv run pytest tests/security/test_agent_integration_matrix.py -v
 ```
 
-See [`integrations/TESTING.md`](../integrations/TESTING.md) for all 72 angles.
+See [`integrations/TESTING.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/TESTING.md) for all 72 angles.
 
 ## Docker E2E (sidecar + examples)
 
@@ -110,4 +110,4 @@ cd sdk && make docker-e2e
 
 ## MCP
 
-For Claude / Cursor MCP server, use [`unplug-mcp`](https://github.com/UnplugAI/unplug-mcp) — see [`integrations/mcp/README.md`](../integrations/mcp/README.md).
+For Claude / Cursor MCP server, use [`unplug-mcp`](https://github.com/UnplugAI/unplug-mcp) — see [`integrations/mcp/README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/mcp/README.md).

--- a/sdk/docs/LIMITS_AND_JUDGE.md
+++ b/sdk/docs/LIMITS_AND_JUDGE.md
@@ -97,9 +97,9 @@ guard = Guard(
 LiteLLM helper (optional extra):
 
 ```python
-from unplug.judge.litellm_judge import make_litellm_judge
+from unplug.judge.litellm_judge import create_litellm_judge
 
-guard = Guard(judge=make_litellm_judge(model="gpt-4o-mini"))
+guard = Guard(judge=create_litellm_judge(model="gpt-4o-mini"))
 ```
 
 ### TOML thresholds only

--- a/sdk/docs/TESTING_HARNESS.md
+++ b/sdk/docs/TESTING_HARNESS.md
@@ -40,7 +40,7 @@ Notes:
   pulls **capability** extras (`ml`, `scrape`, …) but **not** every agent framework.
   Agent SDKs install via the `integrations` meta-extra or one framework at a time.
 - Live framework coverage is a separate workflow (`.github/workflows/integrations-live.yml`).
-  Details: [`integrations/TESTING.md`](../integrations/TESTING.md).
+  Details: [`integrations/TESTING.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/TESTING.md).
 
 ## CI vs local-only
 

--- a/sdk/docs/index.md
+++ b/sdk/docs/index.md
@@ -1,0 +1,52 @@
+# Unplug
+
+**Unplug the bad AI.** Find the attack. Cut the attack. Keep the rest.
+
+Unplug is agent runtime security for LLM applications. It tracks where text came from
+(user vs retrieved vs tool output), scans for prompt injection and destructive actions,
+and enforces tool-call policy, with span-level redaction instead of binary blocking.
+
+```bash
+pip install unplug-ai           # regex-only core, zero ML deps
+pip install "unplug-ai[ml]"     # add the ML span model
+```
+
+```python
+from unplug import Guard, Source
+
+guard = Guard()
+guard.scan("Summarize this page", source="user")
+guard.scan("<hidden>Ignore prior instructions</hidden>", source=Source.RETRIEVED)
+
+result = guard.check_tool_call("send_email", {"to": "attacker@evil.com"})
+print(result.action, result.findings)
+```
+
+Try it without installing anything:
+[live demo](https://huggingface.co/spaces/Unplug-AI/unplug-tiny-demo).
+
+## Where to start
+
+| You are | Read |
+|---------|------|
+| New here | [Getting started](GETTING_STARTED.md) |
+| Wiring an agent host | [Agent actions](AGENT_ACTIONS.md), then [Agent flow security](AGENT_FLOW_SECURITY.md) |
+| Building on a framework | [Integrations](INTEGRATIONS.md) |
+| Deciding whether to trust it | [Benchmarks](BENCHMARKS.md) and [Limits](LIMITS_AND_JUDGE.md) |
+| Deploying | [Deployment](DEPLOYMENT.md) |
+| Contributing | [CONTRIBUTING.md](https://github.com/UnplugAI/Unplug/blob/dev/CONTRIBUTING.md) |
+
+## Language support
+
+Regex and normalization detection is tuned for English today. Ordinary non-English
+input is not treated as an evasion signal on its own. Only genuine zero-width and bidi
+control characters, and mixed-script homoglyph smuggling, get flagged. Multi-language
+detection is tracked separately.
+
+## Getting help
+
+Questions go in
+[Discussions](https://github.com/UnplugAI/Unplug/discussions/categories/q-a).
+Bugs go in [Issues](https://github.com/UnplugAI/Unplug/issues). Vulnerabilities go
+[here](https://github.com/UnplugAI/Unplug/security/advisories/new), never in a public
+issue.

--- a/sdk/docs/index.md
+++ b/sdk/docs/index.md
@@ -34,7 +34,7 @@ Try it without installing anything:
 | Building on a framework | [Integrations](INTEGRATIONS.md) |
 | Deciding whether to trust it | [Benchmarks](BENCHMARKS.md) and [Limits](LIMITS_AND_JUDGE.md) |
 | Deploying | [Deployment](DEPLOYMENT.md) |
-| Contributing | [CONTRIBUTING.md](https://github.com/UnplugAI/Unplug/blob/dev/CONTRIBUTING.md) |
+| Contributing | [Contributing guide](https://github.com/UnplugAI/Unplug/blob/dev/CONTRIBUTING.md) |
 
 ## Language support
 

--- a/sdk/integrations/ag2/README.md
+++ b/sdk/integrations/ag2/README.md
@@ -1,6 +1,6 @@
 # AG2
 
-**Extra:** `pip install "unplug-ai[ag2]"`  
+**Extra:** `pip install "unplug-ai[ag2]"`
 **Module:** `unplug.integrations.ag2`
 
 [AG2](https://docs.ag2.ai/) (the community fork of AutoGen, imported as `autogen`)

--- a/sdk/integrations/agno/README.md
+++ b/sdk/integrations/agno/README.md
@@ -1,6 +1,6 @@
 # Agno
 
-**Extra:** `pip install "unplug-ai[agno]"`  
+**Extra:** `pip install "unplug-ai[agno]"`
 **Module:** `unplug.integrations.agno`
 
 ## Wire Unplug into Agno Agent

--- a/sdk/integrations/atomic-agents/README.md
+++ b/sdk/integrations/atomic-agents/README.md
@@ -1,6 +1,6 @@
 # Atomic Agents
 
-**Extra:** `pip install "unplug-ai[atomic-agents]"`  
+**Extra:** `pip install "unplug-ai[atomic-agents]"`
 **Module:** `unplug.integrations.atomic_agents`
 
 [Atomic Agents](https://brainblend-ai.github.io/atomic-agents/) (v2) is a

--- a/sdk/integrations/autogen/README.md
+++ b/sdk/integrations/autogen/README.md
@@ -1,6 +1,6 @@
 # Microsoft AutoGen
 
-**Extra:** `pip install "unplug-ai[autogen]"`  
+**Extra:** `pip install "unplug-ai[autogen]"`
 **Module:** `unplug.integrations.autogen`
 
 ## Wire Unplug into AutoGen agents

--- a/sdk/integrations/crewai/README.md
+++ b/sdk/integrations/crewai/README.md
@@ -1,6 +1,6 @@
 # CrewAI
 
-**Extra:** `pip install "unplug-ai[crewai]"`  
+**Extra:** `pip install "unplug-ai[crewai]"`
 **Module:** `unplug.integrations.crewai`
 
 ## Wire Unplug into a Crew

--- a/sdk/integrations/dspy/README.md
+++ b/sdk/integrations/dspy/README.md
@@ -1,6 +1,6 @@
 # DSPy
 
-**Extra:** `pip install "unplug-ai[dspy]"`  
+**Extra:** `pip install "unplug-ai[dspy]"`
 **Module:** `unplug.integrations.dspy`
 
 [DSPy](https://dspy.ai/) programs are `dspy.Module` subclasses with a `forward`

--- a/sdk/integrations/google-adk/README.md
+++ b/sdk/integrations/google-adk/README.md
@@ -1,6 +1,6 @@
 # Google ADK
 
-**Extra:** `pip install "unplug-ai[google-adk]"`  
+**Extra:** `pip install "unplug-ai[google-adk]"`
 **Module:** `unplug.integrations.google_adk`
 
 Google's [Agent Development Kit](https://google.github.io/adk-docs/) exposes

--- a/sdk/integrations/griptape/README.md
+++ b/sdk/integrations/griptape/README.md
@@ -1,6 +1,6 @@
 # Griptape
 
-**Extra:** `pip install "unplug-ai[griptape]"`  
+**Extra:** `pip install "unplug-ai[griptape]"`
 **Module:** `unplug.integrations.griptape`
 
 [Griptape](https://griptape.ai/) structures (Agent, Pipeline, Workflow) run Tasks.

--- a/sdk/integrations/haystack/README.md
+++ b/sdk/integrations/haystack/README.md
@@ -1,6 +1,6 @@
 # Haystack (RAG)
 
-**Extra:** `pip install "unplug-ai[haystack]"`  
+**Extra:** `pip install "unplug-ai[haystack]"`
 **Module:** `unplug.integrations.haystack`
 
 Defend the **retrieval path** — poisoned documents are the most common indirect injection vector.

--- a/sdk/integrations/langchain/README.md
+++ b/sdk/integrations/langchain/README.md
@@ -1,6 +1,6 @@
 # LangChain
 
-**Extra:** `pip install "unplug-ai[langchain]"`  
+**Extra:** `pip install "unplug-ai[langchain]"`
 **Module:** `unplug.integrations.langchain`
 
 > For **LangGraph** graphs, use the dedicated [`langgraph`](../langgraph/README.md)

--- a/sdk/integrations/langgraph/README.md
+++ b/sdk/integrations/langgraph/README.md
@@ -1,6 +1,6 @@
 # LangGraph
 
-**Extra:** `pip install "unplug-ai[langgraph]"`  
+**Extra:** `pip install "unplug-ai[langgraph]"`
 **Module:** `unplug.integrations.langgraph`
 
 ## Wire Unplug into a graph

--- a/sdk/integrations/letta/README.md
+++ b/sdk/integrations/letta/README.md
@@ -1,6 +1,6 @@
 # Letta
 
-**Extra:** `pip install "unplug-ai[letta]"`  
+**Extra:** `pip install "unplug-ai[letta]"`
 **Module:** `unplug.integrations.letta`
 
 [Letta](https://docs.letta.com/) (formerly MemGPT) runs persistent, stateful

--- a/sdk/integrations/llama-index/README.md
+++ b/sdk/integrations/llama-index/README.md
@@ -1,6 +1,6 @@
 # LlamaIndex
 
-**Extra:** `pip install "unplug-ai[llama-index]"`  
+**Extra:** `pip install "unplug-ai[llama-index]"`
 **Module:** `unplug.integrations.llama_index`
 
 Uses the same scanning core as Haystack (`scan_document`) — no LlamaIndex import at load time.

--- a/sdk/integrations/mcp/README.md
+++ b/sdk/integrations/mcp/README.md
@@ -1,6 +1,6 @@
 # MCP (Model Context Protocol)
 
-**Extra:** `pip install "unplug-ai[mcp]"` for client-side MCP tooling tests.  
+**Extra:** `pip install "unplug-ai[mcp]"` for client-side MCP tooling tests.
 **Server:** use the standalone [`unplug-mcp`](https://github.com/UnplugAI/unplug-mcp) package for Claude Code / Cursor.
 
 ## Hosted MCP server (recommended)

--- a/sdk/integrations/openai-agents/README.md
+++ b/sdk/integrations/openai-agents/README.md
@@ -1,6 +1,6 @@
 # OpenAI Agents SDK
 
-**Extra:** `pip install "unplug-ai[openai-agents]"`  
+**Extra:** `pip install "unplug-ai[openai-agents]"`
 **Module:** `unplug.integrations.openai_agents`
 
 The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) has a

--- a/sdk/integrations/pydantic-ai/README.md
+++ b/sdk/integrations/pydantic-ai/README.md
@@ -1,6 +1,6 @@
 # Pydantic AI
 
-**Extra:** `pip install "unplug-ai[pydantic-ai]"`  
+**Extra:** `pip install "unplug-ai[pydantic-ai]"`
 **Module:** `unplug.integrations.pydantic_ai`
 
 ## Validators around Agent.run

--- a/sdk/integrations/semantic-kernel/README.md
+++ b/sdk/integrations/semantic-kernel/README.md
@@ -1,6 +1,6 @@
 # Semantic Kernel
 
-**Extra:** `pip install "unplug-ai[semantic-kernel]"`  
+**Extra:** `pip install "unplug-ai[semantic-kernel]"`
 **Module:** `unplug.integrations.semantic_kernel`
 
 > **Wheel-only installs:** `semantic-kernel` depends on `pybars4`, which publishes

--- a/sdk/integrations/smolagents/README.md
+++ b/sdk/integrations/smolagents/README.md
@@ -1,6 +1,6 @@
 # smolagents
 
-**Extra:** `pip install "unplug-ai[smolagents]"`  
+**Extra:** `pip install "unplug-ai[smolagents]"`
 **Module:** `unplug.integrations.smolagents`
 
 Hugging Face [smolagents](https://huggingface.co/docs/smolagents) runs code and

--- a/sdk/integrations/strands/README.md
+++ b/sdk/integrations/strands/README.md
@@ -1,6 +1,6 @@
 # Strands Agents
 
-**Extra:** `pip install "unplug-ai[strands]"`  
+**Extra:** `pip install "unplug-ai[strands]"`
 **Module:** `unplug.integrations.strands`
 
 [Strands Agents](https://strandsagents.com/) (AWS) exposes a strongly-typed

--- a/sdk/scripts/check_doc_drift.py
+++ b/sdk/scripts/check_doc_drift.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""Fail when the docs describe an API that does not exist.
+
+Walks every ```python fence in sdk/docs/ and the repo-root markdown, collects the
+`from unplug... import X` / `import unplug...` statements, and checks each one
+actually resolves. Catches the case where a symbol gets renamed in code and the
+docs keep the old name, which a reader only discovers by pasting the snippet and
+getting an ImportError.
+
+Optional extras that are not installed are skipped, not failed, so this runs the
+same on a minimal `uv sync --dev` as it does on a full CI environment.
+
+Usage: uv run python scripts/check_doc_drift.py
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import re
+import sys
+from pathlib import Path
+
+FENCE_RE = re.compile(r"```python\n(.*?)```", re.DOTALL)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_GLOBS = ("sdk/docs/*.md", "*.md", "sdk/*.md", "sdk/integrations/*/README.md")
+
+# The docs deliberately reference the old name in these files.
+SKIP_FILES = {"MIGRATION.md", "CHANGELOG.md"}
+
+
+def _extras_missing(exc: BaseException) -> bool:
+    text = str(exc)
+    return "requires the extra" in text or (
+        isinstance(exc, ModuleNotFoundError) and not text.startswith("No module named 'unplug")
+    )
+
+
+def _imports(source: str) -> list[tuple[str, str | None]]:
+    """Return (module, symbol) pairs for unplug imports in one code fence."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    found: list[tuple[str, str | None]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module and node.module.split(".")[0] == "unplug":
+                found.extend((node.module, alias.name) for alias in node.names)
+        elif isinstance(node, ast.Import):
+            found.extend(
+                (alias.name, None) for alias in node.names if alias.name.split(".")[0] == "unplug"
+            )
+    return found
+
+
+def main() -> int:
+    broken: list[str] = []
+    skipped = 0
+    checked = 0
+
+    paths = sorted({p for g in DOC_GLOBS for p in REPO_ROOT.glob(g)})
+    for path in paths:
+        if path.name in SKIP_FILES:
+            continue
+        rel = path.relative_to(REPO_ROOT)
+        for fence in FENCE_RE.findall(path.read_text(encoding="utf-8")):
+            for module, symbol in _imports(fence):
+                checked += 1
+                try:
+                    mod = importlib.import_module(module)
+                except ImportError as exc:
+                    if _extras_missing(exc):
+                        skipped += 1
+                        continue
+                    broken.append(f"{rel}: cannot import {module} ({exc})")
+                    continue
+                except Exception as exc:  # noqa: BLE001 - report, do not crash the check
+                    broken.append(f"{rel}: importing {module} raised {type(exc).__name__}: {exc}")
+                    continue
+
+                if symbol is None:
+                    continue
+                try:
+                    if not hasattr(mod, symbol):
+                        broken.append(f"{rel}: {module} has no '{symbol}'")
+                except Exception:  # noqa: BLE001 - lazy attr needing an absent extra
+                    skipped += 1
+
+    print(f"checked {checked} doc imports across {len(paths)} files ({skipped} skipped: extras)")
+    if broken:
+        print("\ndocs reference APIs that do not exist:")
+        for line in broken:
+            print(f"  {line}")
+        print("\nUpdate the docs, or the symbol, so a reader can paste the snippet and run it.")
+        return 1
+    print("no drift")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdk/scripts/check_doc_drift.py
+++ b/sdk/scripts/check_doc_drift.py
@@ -75,7 +75,8 @@ def main() -> int:
                         continue
                     broken.append(f"{rel}: cannot import {module} ({exc})")
                     continue
-                except Exception as exc:  # noqa: BLE001 - report, do not crash the check
+                except Exception as exc:
+                    # Report and keep going; one bad module should not hide the rest.
                     broken.append(f"{rel}: importing {module} raised {type(exc).__name__}: {exc}")
                     continue
 
@@ -84,7 +85,8 @@ def main() -> int:
                 try:
                     if not hasattr(mod, symbol):
                         broken.append(f"{rel}: {module} has no '{symbol}'")
-                except Exception:  # noqa: BLE001 - lazy attr needing an absent extra
+                except Exception:
+                    # Lazy attribute that needs an extra we do not have installed.
                     skipped += 1
 
     print(f"checked {checked} doc imports across {len(paths)} files ({skipped} skipped: extras)")


### PR DESCRIPTION
Gets the repo ready for people arriving from outside.

Docs site. mkdocs-material over `sdk/docs`, deployed to Pages from `dev`.
The build runs with `--strict` on PRs, which caught two dead links in
ARCHITECTURE.md (RESTRUCTURE_PLAN.md and LOGIC_AUDIT.md were never
committed) and 14 relative links that escaped `sdk/docs`. Those are now
absolute GitHub URLs so they work in both renderers.

pre-commit. Closes #119. Hooks are the fast half of `make check`, so
ruff stops being a CI failure. First run fixed trailing whitespace in
22 markdown files.

AI_POLICY.md. Disclose model-written patches or the PR gets closed.
Same quality bar either way. PR template has a checkbox.

Mentored issues. The `mentored` label existed and nothing explained it.
CONTRIBUTING now says what you get and what we ask back.

SUPPORT.md and ROADMAP.md. Neither existed. README had no contributing
section at all.

Triage automation. `needs-triage` on every new issue from outside, and a
weekly sweep that nudges claimed issues after 21 days of silence and
unassigns 7 days later, which is the promise CONTRIBUTING already makes.
The sweep was run against fixture issues covering maintainer-assigned,
unassigned, mixed-assignee, and inside-grace-period cases; it also takes
a `dry_run` input.

Also fixes a stale number: README said regex-only detection is
F1 0.56 / recall 0.39. BENCHMARKS.md has said 0.575 / 0.405 since the
Phase C refresh in #80. README predates it. Corrected to 0.58 / 0.41.
That line also mentions `Guard.with_tiny()`, which is #118's job, so the
API name is untouched here.

Labels created. Pages still needs to be set to build from GitHub Actions
before the deploy job can run.
