### PR TITLE
docs: replaced remaining Guard.with_tiny() references with Guard(mode…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ print(result.findings) # evidence with span offsets
 One line upgrades detection to the ML span model (downloads [unplug-tiny-v1](https://huggingface.co/Unplug-AI/unplug-tiny-v1) once, cached):
 
 ```python
-guard = Guard(model="tiny", auto_download_model=True)
+guard = Guard(model="tiny", auto_download_model=True, require_ml=True)
 ```
 
 Try it without installing anything: [live demo](https://huggingface.co/spaces/Unplug-AI/unplug-tiny-demo).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ print(result.findings) # evidence with span offsets
 One line upgrades detection to the ML span model (downloads [unplug-tiny-v1](https://huggingface.co/Unplug-AI/unplug-tiny-v1) once, cached):
 
 ```python
-guard = Guard.with_tiny()
+guard = Guard(model="tiny", auto_download_model=True)
 ```
 
 Try it without installing anything: [live demo](https://huggingface.co/spaces/Unplug-AI/unplug-tiny-demo).
@@ -71,16 +71,20 @@ Try it without installing anything: [live demo](https://huggingface.co/spaces/Un
 | TaintedText provenance + session taint | **Included** |
 | Tool-call enforcement (destructive block, tainted review) | **Included** |
 | Span-level redaction | **Included** |
-| ML span model `Guard.with_tiny()` | **Preview** ([unplug-tiny-v1](https://huggingface.co/Unplug-AI/unplug-tiny-v1)) |
+| ML span model `Guard(model="tiny")` | **Preview** ([unplug-tiny-v1](https://huggingface.co/Unplug-AI/unplug-tiny-v1)) |
 | Sliding-window long documents + streaming scan | **Included** |
 
-On the neuralchemy prompt-injection set, regex-only detection reaches **F1 0.58 / recall 0.41** — a fast first line, not sufficient alone. Adding the ML span model (`Guard.with_tiny()`) takes that to **F1 0.99 / recall 0.98**, and lifts recall on *indirect* injection from **0.05 → 0.91**. False-positive rate stays under 1% on the injection set (2.1% on a separate hard-benign corpus). Full tables, methodology, and honest caveats: [`sdk/docs/BENCHMARKS.md`](sdk/docs/BENCHMARKS.md). Per-axis model metrics (including failure modes) are on the [model card](https://huggingface.co/Unplug-AI/unplug-tiny-v1).
+
+On the neuralchemy prompt-injection set, regex-only detection reaches **F1 0.58 / recall 0.41** — a fast first line, not sufficient alone. Adding the ML span model (`Guard(model="tiny")`) takes that to **F1 0.99 / recall 0.98**, and lifts recall on *indirect* injection from **0.05 → 0.91**. False-positive rate stays under 1% on the injection set (2.1% on a separate hard-benign corpus). Full tables, methodology, and honest caveats: [`sdk/docs/BENCHMARKS.md`](sdk/docs/BENCHMARKS.md). Per-axis model metrics (including failure modes) are on the [model card](https://huggingface.co/Unplug-AI/unplug-tiny-v1).
 
 **Language support.** Regex + normalization detection is tuned for English today.
 Ordinary non-English input (Cyrillic, CJK, etc.) is *not* treated as an evasion
 signal — only genuine zero-width/bidi control characters and mixed-script
 homoglyph smuggling are flagged. Robust multi-language injection detection is
 tracked as a separate work item.
+
+On the neuralchemy prompt-injection set, regex-only detection reaches **F1 0.56 / recall 0.39** — a fast first line, not sufficient alone. Adding the ML span model (`Guard(model="tiny")`) takes that to **F1 0.99 / recall 0.98**, and lifts recall on *indirect* injection from **0.05 → 0.91**. False-positive rate stays under 1% on the injection set (2.1% on a separate hard-benign corpus). Full tables, methodology, and honest caveats: [`sdk/docs/BENCHMARKS.md`](sdk/docs/BENCHMARKS.md). Per-axis model metrics (including failure modes) are on the [model card](https://huggingface.co/Unplug-AI/unplug-tiny-v1).
+>>>>>>> b27d848 (docs: replaced remaining Guard.with_tiny() references with Guard(model='tiny'))
 
 ## Agent host checklist
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ signal — only genuine zero-width/bidi control characters and mixed-script
 homoglyph smuggling are flagged. Robust multi-language injection detection is
 tracked as a separate work item.
 
-On the neuralchemy prompt-injection set, regex-only detection reaches **F1 0.56 / recall 0.39** — a fast first line, not sufficient alone. Adding the ML span model (`Guard(model="tiny")`) takes that to **F1 0.99 / recall 0.98**, and lifts recall on *indirect* injection from **0.05 → 0.91**. False-positive rate stays under 1% on the injection set (2.1% on a separate hard-benign corpus). Full tables, methodology, and honest caveats: [`sdk/docs/BENCHMARKS.md`](sdk/docs/BENCHMARKS.md). Per-axis model metrics (including failure modes) are on the [model card](https://huggingface.co/Unplug-AI/unplug-tiny-v1).
->>>>>>> b27d848 (docs: replaced remaining Guard.with_tiny() references with Guard(model='tiny'))
 
 ## Agent host checklist
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ print(result.findings) # evidence with span offsets
 One line upgrades detection to the ML span model (downloads [unplug-tiny-v1](https://huggingface.co/Unplug-AI/unplug-tiny-v1) once, cached):
 
 ```python
-guard = Guard(model="tiny", auto_download_model=True, require_ml=True)
+guard = Guard(model="tiny", auto_download_model=True)
 ```
 
 Try it without installing anything: [live demo](https://huggingface.co/spaces/Unplug-AI/unplug-tiny-demo).

--- a/sdk/benchmarks/run.py
+++ b/sdk/benchmarks/run.py
@@ -31,7 +31,7 @@ def main() -> None:
     parser.add_argument(
         "--ml",
         action="store_true",
-        help="Use Guard.with_tiny() (ML second-pass) instead of regex-only",
+        help="Use Guard(model='tiny') (ML second-pass) instead of regex-only",
     )
     parser.add_argument(
         "--isolated",

--- a/sdk/scripts/smoke_ml_hooks.py
+++ b/sdk/scripts/smoke_ml_hooks.py
@@ -2,7 +2,7 @@
 """Offline smoke: synthetic ML checkpoint + Guard + one hooks adapter.
 
 No Hugging Face download and no agent-framework install required. Builds a tiny
-random BIOES checkpoint, wires Guard.with_tiny against it, then exercises the
+random BIOES checkpoint, wires Guard(model="tiny") against it, then exercises the
 LangGraph-style AgentHooks adapters (same surface as examples/langgraph_hooks_demo.py).
 """
 


### PR DESCRIPTION
…l='tiny')

    Closes #118

    Note: the issue cited README.md:60, but the root README had three total
    with_tiny references (quickstart, 'What ships today' table, and the benchmark
    paragraph). Updated all three for consistency within the file. MIGRATION.md
    and the deprecation test left untouched as instructed.

# Summary

<!-- What does this PR change, and why? -->

Replaced the remaining `Guard.with_tiny()` references with the new `Guard(model="tiny")` API in:
    1. `README.md` (quickstart, "What ships today" table, benchmark paragraph)
    2. `sdk/benchmarks/run.py` (`--ml` help text)
    3. `sdk/scripts/smoke_ml_hooks.py` (module docstring)

## Checklist

- [X] The issue this closes was assigned to me (see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [X] This is my only open PR, or my first PR has already been merged
- [X] Target branch is `dev` (see [BRANCHING.md](BRANCHING.md))
- [ ] `cd sdk && make check-ci` passes locally
- [ ] New code has tests (every module gets a test file)
- [ ] Public API changes are reflected in `sdk/README.md` / `sdk/docs/`
- [X] No secrets, internal URLs, or private paths in the diff

