### PR TITLE
Fix the triage workflow if expression

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -15,9 +15,10 @@ permissions:
 
 jobs:
   label:
-    if: >
-      !contains(fromJSON('["OWNER","MEMBER"]'),
-      github.event.issue.author_association)
+    # Must be wrapped in ${{ }} and kept on one line. An `if` expression starting
+    # with `!` does not evaluate correctly in the bare or folded form; it silently
+    # comes out truthy, so every maintainer-filed issue got labelled anyway.
+    if: ${{ !contains(fromJSON('["OWNER","MEMBER"]'), github.event.issue.author_association) }}
     runs-on: ubuntu-latest
     steps:
       - name: Add needs-triage


### PR DESCRIPTION
Every maintainer-filed issue is getting `needs-triage`, including #133 through #141
which I opened as OWNER.

The job condition was:

```yaml
if: >
  !contains(fromJSON('["OWNER","MEMBER"]'),
  github.event.issue.author_association)
```

`author_association` is `MEMBER`, which is in the list, so the job should skip. It
does not. The run shows `conclusion=success` rather than skipped, and
github-actions[bot] applies the label.

An `if` expression that starts with `!` has to be wrapped in `${{ }}`. In the bare or
folded form it comes out truthy instead of erroring, so the exemption never applied
and every issue since #126 merged has been labelled regardless of who opened it.

Now one line, wrapped:

```yaml
if: ${{ !contains(fromJSON('["OWNER","MEMBER"]'), github.event.issue.author_association) }}
```

Verifiable after merge by opening an issue as a maintainer and checking the job skips.