### PR TITLE
test(security): move wall-clock scan-latency assertions off the PR gate (#144)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           if [ "${{ matrix.python-version }}" = "3.13" ]; then
             make lint
             uv run ruff format --check .
-            uv run pytest -q -m "not requires_docker and not requires_ml and not requires_ml_weights"
+            uv run pytest -q -m "not requires_docker and not requires_ml and not requires_ml_weights and not slow"
           else
             make check-ci
           fi

--- a/.github/workflows/slow-stress.yml
+++ b/.github/workflows/slow-stress.yml
@@ -1,0 +1,42 @@
+name: Slow stress tests
+
+# Wall-clock scan-latency assertions (tests/security/test_security_stress.py) are
+# intentionally excluded from the default/PR gate: shared runners vary too much
+# for absolute time budgets, and a flake there looks like a real regression on
+# an unrelated PR (#144). They run here — nightly on dev and on manual dispatch —
+# where a failure gets investigated instead of blocking a PR.
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  slow-stress:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+          version: "0.6.14"
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        # Slow stress tests only need the core package + pytest.
+        run: uv sync --dev
+
+      - name: Run slow stress tests
+        # The explicit `-m slow` overrides the default addopts deselect
+        # (`not ... and not slow`), so only the wall-clock tests run here.
+        run: uv run pytest -q -m slow -v

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -1,5 +1,5 @@
 .PHONY: install lint typecheck format fix check check-ci check-docs test test-cov test-security \
-	test-ml test-ml-harness test-frameworks test-frameworks-live test-all-local \
+	test-slow test-ml test-ml-harness test-frameworks test-frameworks-live test-all-local \
 	smoke-ml smoke-ml-hooks docker-e2e audit audit-ml scenarios attack-gate examples
 
 install:
@@ -91,9 +91,14 @@ test-cov:
 test-security:
 	uv run pytest tests/security tests/unit/core/agent/test_agent_hardening.py -v
 
+# Wall-clock scan-latency stress tests. Excluded from the default/PR gate
+# (pyproject.toml addopts); run here and nightly via the slow-stress workflow.
+test-slow:
+	uv run pytest -q -m slow -v
+
 # Local pre-release composition: CI parity + frameworks + ML harness + examples.
 # Does not run docker-e2e or live framework installs (see docs/TESTING_HARNESS.md).
-test-all-local: check-ci test-cov test-frameworks test-ml-harness examples
+test-all-local: check-ci test-cov test-frameworks test-ml-harness examples test-slow
 
 audit:
 	uv run unplug-audit

--- a/sdk/docs/TESTING_HARNESS.md
+++ b/sdk/docs/TESTING_HARNESS.md
@@ -16,7 +16,8 @@ Commands for validating the SDK before a release cut. Run from `sdk/` after
 | `make smoke-ml` | `scripts/smoke_local_ml.py` + `unplug-audit --require-ml` |
 | `make smoke-ml-hooks` | Offline synthetic checkpoint + Guard + LangGraph-style hooks |
 | `make examples` | Demo scripts + `tests/integration/test_examples.py` |
-| `make test-all-local` | `check-ci` + `test-cov` + `test-frameworks` + `test-ml-harness` + `examples` |
+| `make test-slow` | Wall-clock scan-latency stress tests (excluded from `check-ci`; see below) |
+| `make test-all-local` | `check-ci` + `test-cov` + `test-frameworks` + `test-ml-harness` + `examples` + `test-slow` |
 
 One-liner for a thorough local pass:
 
@@ -55,7 +56,14 @@ Notes:
 | Offline ML+hooks smoke | Not in CI gate | `make smoke-ml-hooks` |
 | Examples demos | Partial (exfil in `check-ci`) | `make examples` |
 | Live framework imports | `integrations-live` workflow (path/nightly) | `make test-frameworks-live` |
+| Slow stress (wall-clock latency) | `slow-stress` workflow (nightly + manual dispatch); excluded from the PR gate | `make test-slow` |
 | Docker E2E | No | `make docker-e2e` (`RUN_DOCKER_E2E=1`) |
+
+Slow stress tests are off the PR gate on purpose: they assert wall-clock scan
+latency, and shared CI runners (or loaded dev machines) vary enough to flake
+an absolute time budget (issue #144). A failure in the nightly
+`slow-stress` workflow is a real regression signal — or a hint that the
+`not slow` deselect fell off the gate — not PR noise.
 
 ## ML checkpoint
 

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -235,7 +235,14 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-addopts = ["-m", "not requires_docker"]
+# Wall-clock scan-latency assertions in tests/security/test_security_stress.py
+# are deselected from the default gate: shared CI runners (and loaded dev
+# machines) vary too much for absolute time budgets, and a flake here looks
+# like a real regression on an unrelated PR (#144). They run on a schedule /
+# manual dispatch via .github/workflows/slow-stress.yml and locally via
+# `make test-slow`. The policy lives in the test file so the budgets are not
+# "fixed" by nudging the numbers.
+addopts = ["-m", "not requires_docker and not slow"]
 markers = [
     "requires_ml_weights: tests needing checkpoint weight files on disk",
     "requires_docker: tests needing docker daemon (sidecar E2E)",
@@ -243,7 +250,7 @@ markers = [
     "requires_yara: tests needing yara-python extra",
     "requires_ml: tests needing ML stack extra",
     "requires_integrations: tests needing agent framework extras",
-    "slow: timing-sensitive stress tests (skipped in coverage CI rerun)",
+    "slow: wall-clock stress tests; excluded from the default/PR gate, run via the nightly slow-stress workflow or `make test-slow`",
 ]
 filterwarnings = [
     "ignore:clean_up_tokenization_spaces:FutureWarning:transformers.tokenization_utils_base",

--- a/sdk/tests/security/test_security_stress.py
+++ b/sdk/tests/security/test_security_stress.py
@@ -1,4 +1,20 @@
-"""S6: Security stress tests: registry limits, ReDoS guards, scan latency."""
+"""S6: Security stress tests: registry limits, ReDoS guards, scan latency.
+
+Policy for the wall-clock assertions below (issue #144):
+
+* These tests are marked `slow` and are deselected from the default/PR gate
+  (pyproject.toml addopts). They run nightly / on manual dispatch via
+  .github/workflows/slow-stress.yml, and locally via `make test-slow`.
+* Absolute time budgets mean different things on different machines — the
+  benign-lines scan has been observed from ~250 ms (fast laptop) to ~2.2 s
+  (loaded Windows dev box) with the same code — so the numbers are
+  deliberately loose. They exist to catch order-of-magnitude regressions
+  (e.g. accidentally superlinear scan behaviour), not normal variance.
+* The two budgets are paired and must move TOGETHER: if one needs to change,
+  change both and update this comment. Do not "fix" a flake by nudging a
+  number — if these fail on a runner, the scan has genuinely regressed or
+  the `not slow` deselect fell off the gate.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +24,9 @@ import pytest
 
 from unplug import Guard
 from unplug.core.privacy.secrets import SecretsRegistry
+
+# Loose by design — see the policy note at the top of this file.
+SCAN_LATENCY_BUDGET_MS = 5000.0
 
 
 class TestSecretsRegistryStress:
@@ -31,7 +50,7 @@ class TestSecretsRegistryStress:
 
 class TestScanLatencyStress:
     @pytest.mark.slow
-    def test_ten_k_benign_lines_under_500ms(self, guard: Guard) -> None:
+    def test_ten_k_benign_lines_scan_latency(self, guard: Guard) -> None:
         line = "Please summarize the quarterly report for the finance team."
         # Stay under default LimitConfig max_input_length (50k chars).
         text = "\n".join([line] * 800)
@@ -39,7 +58,7 @@ class TestScanLatencyStress:
         result = guard.scan(text)
         elapsed_ms = (time.perf_counter() - start) * 1000
         assert result.safe is True
-        assert elapsed_ms < 500.0
+        assert elapsed_ms < SCAN_LATENCY_BUDGET_MS
 
     @pytest.mark.slow
     def test_repeated_scans_stable(self, guard: Guard) -> None:
@@ -48,7 +67,7 @@ class TestScanLatencyStress:
         for _ in range(200):
             guard.scan(text)
         elapsed_ms = (time.perf_counter() - start) * 1000
-        assert elapsed_ms < 500.0
+        assert elapsed_ms < SCAN_LATENCY_BUDGET_MS
 
 
 @pytest.fixture


### PR DESCRIPTION
# Summary

Moves the wall-clock scan-latency assertions off the PR gate (closes #144). The 500 ms budgets flaked on shared runners (e.g. 634 ms on #97). The two latency tests are now marked `slow` and deselected from the gate; both use one loose constant `SCAN_LATENCY_BUDGET_MS = 5000.0`; a new `slow-stress.yml` runs them nightly + manual dispatch; `make test-slow` runs them locally. Policy is written down in the test docstring so nobody "fixes" a flake by nudging numbers.

## Test report

- Gate deselection works: 2 slow tests deselected from default run
- `uv run pytest -q -m slow -v` → 2 passed (benign-lines scan measured 1.28 s locally — would have failed the old 500 ms budget)
- `ruff check` / `mypy` / `ruff format --check` pass; full suite 1121 passed, 29 skipped, 3 deselected; scenarios 4/4, attack-gate PASS; new workflow YAML parses

## Checklist

- [x] The issue this closes was assigned to me (see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [ ] This is my only open PR (one issue at a time, see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [x] Target branch is `dev` (see [BRANCHING.md](BRANCHING.md))
- [ ] `cd sdk && make check-ci` passes locally
- [x] New code has tests (every module gets a test file)
- [x] Public API changes are reflected in `sdk/README.md` / `sdk/docs/`
- [x] No secrets, internal URLs, or private paths in the diff
- [ ] If a model wrote a meaningful part of this, I said so below ([AI_POLICY.md](../AI_POLICY.md))

## Notes for reviewers

- `-m slow` on the CLI overrides the `not slow` in `addopts` that's how `slow-stress.yml` / `make test-slow` run only these tests.
- If a slow test fails now, the scan genuinely regressed (or the deselect fell off the gate) don't nudge the budget.
