### PR TITLE
docs: add reading order for the security model to GETTING_STARTED.md

### DIFF
--- a/sdk/docs/GETTING_STARTED.md
+++ b/sdk/docs/GETTING_STARTED.md
@@ -91,6 +91,15 @@ pip install unplug-ai
 python -c "from unplug import Guard; print(Guard().scan('hello', source='user').safe)"
 ```
 
+## What to read next
+
+| Goal | Doc |
+|------|-----|
+| Wire Unplug into **your** agent loop | [`integrations/custom-loop/README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/custom-loop/README.md) |
+| LangGraph, CrewAI, OpenAI Agents, … | [`integrations/README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/README.md) |
+| Full SDK reference | [`README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/README.md) |
+| Hosted API / sidecar | [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) |
+
 ## Understanding the security model
 
 If you want to know why Unplug makes the decisions it does, read these in order:

--- a/sdk/docs/GETTING_STARTED.md
+++ b/sdk/docs/GETTING_STARTED.md
@@ -91,15 +91,18 @@ pip install unplug-ai
 python -c "from unplug import Guard; print(Guard().scan('hello', source='user').safe)"
 ```
 
-## What to read next
+## Understanding the security model
+
+If you want to know why Unplug makes the decisions it does, read these in order:
 
 | Goal | Doc |
 |------|-----|
-| Wire Unplug into **your** agent loop | [`integrations/custom-loop/README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/custom-loop/README.md) |
-| LangGraph, CrewAI, OpenAI Agents, … | [`integrations/README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/integrations/README.md) |
-| **REVIEW** vs **BLOCK** (human approval) | [`docs/AGENT_ACTIONS.md`](AGENT_ACTIONS.md) |
-| Full SDK reference | [`README.md`](https://github.com/UnplugAI/Unplug/blob/dev/sdk/README.md) |
-| Hosted API / sidecar | [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) |
+| The mental model: Guard → Pipelines → Scanners → Core, and how TaintedText/TrustLevel mark untrusted spans. Start here. | [`ARCHITECTURE.md`](ARCHITECTURE.md) |
+| What happens to a marked span next: redact, block, or review. | [`AGENT_ACTIONS.md`](AGENT_ACTIONS.md) |
+| Taint and actions across a full agent loop — session taint, `notify_taint_source`, adaptive degradation. | [`AGENT_FLOW_SECURITY.md`](AGENT_FLOW_SECURITY.md) |
+| A worked example of the above: scanning context files, skills, and cron prompts before they reach the model. | [`HERMES_AGENT_SECURITY.md`](HERMES_AGENT_SECURITY.md) |
+| The same taint/redact ideas applied to retrieval (RAG). | [`RAG_DEFENSE.md`](RAG_DEFENSE.md) |
+| Once the model above makes sense, which imports to build against. | [`PUBLIC_API.md`](PUBLIC_API.md) |
 
 ## Common mistakes
 


### PR DESCRIPTION
# Summary

<!-- What does this PR change, and why? -->

## Checklist

- [ ] The issue this closes was assigned to me (see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [ ] This is my only open PR (one issue at a time, see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [ ] Target branch is `dev` (see [BRANCHING.md](BRANCHING.md))
- [ ] `cd sdk && make check-ci` passes locally
- [ ] New code has tests (every module gets a test file)
- [ ] Public API changes are reflected in `sdk/README.md` / `sdk/docs/`
- [ ] No secrets, internal URLs, or private paths in the diff
- [ ] If a model wrote a meaningful part of this, I said so below ([AI_POLICY.md](../AI_POLICY.md))

## Notes for reviewers

<!-- Anything that needs extra attention: tricky spans, security-sensitive logic, perf. -->
