### PR TITLE
docs: replaced remaining Guard.with_tiny() references with Guard(mode…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ uv sync --dev
 
 | Extra | Enables |
 |-------|---------|
-| `ml` | ML span model (`Guard.with_tiny()`) |
+| `ml` | ML span model (`Guard(model="tiny")`) |
 | `yara` | YARA code/SQLi/XSS scanner |
 | `presidio` | Presidio PII scanner |
 | `litellm` | LLM judge for borderline cases |

--- a/assets/hf-org-card/README.md
+++ b/assets/hf-org-card/README.md
@@ -36,7 +36,7 @@ pip install "unplug-ai[ml]"
 ```python
 from unplug import Guard
 
-guard = Guard.with_tiny()              # auto-downloads unplug-tiny-v1
+guard = Guard(model="tiny")              # auto-downloads unplug-tiny-v1
 result = guard.scan(untrusted_text)
 if not result.safe:
     use(result.redacted_text)          # attack removed, content preserved

--- a/assets/hf-org-card/README.md
+++ b/assets/hf-org-card/README.md
@@ -36,7 +36,7 @@ pip install "unplug-ai[ml]"
 ```python
 from unplug import Guard
 
-guard = Guard(model="tiny")              # auto-downloads unplug-tiny-v1
+guard = Guard(model="tiny",auto_download_model=True)              # auto-downloads unplug-tiny-v1
 result = guard.scan(untrusted_text)
 if not result.safe:
     use(result.redacted_text)          # attack removed, content preserved


### PR DESCRIPTION
Closes #148

# Summary

Successfully replaced "(Guard.with_tiny())" in two remaining files(i.e. CONTRIBUTING.md and assets/hf-org-card/README.md) with "Guard(model='tiny')". 

## Checklist

- [X] The issue this closes was assigned to me (see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [X] This is my only open PR (one issue at a time, see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [X] Target branch is `dev` (see [BRANCHING.md](BRANCHING.md))
- [ ] `cd sdk && make check-ci` passes locally
- [ ] New code has tests (every module gets a test file)
- [ ] Public API changes are reflected in `sdk/README.md` / `sdk/docs/`
- [X] No secrets, internal URLs, or private paths in the diff
- [ ] If a model wrote a meaningful part of this, I said so below ([AI_POLICY.md](../AI_POLICY.md))
