### PR TITLE
fix(guard): report error stage and latency on fail-closed results

### DIFF
--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import threading
+import time
 from typing import Any, ClassVar
 
 from unplug.api.enums import Action, Source
@@ -50,7 +51,7 @@ from unplug.streaming import StreamScanner, scan_stream
 _log = get_logger("guard")
 
 
-def _fail_closed(exc: Exception) -> ScanResult:
+def _fail_closed(exc: Exception, latency_ms: float = 0.0) -> ScanResult:
     return ScanResult(
         safe=False,
         action=Action.BLOCK,
@@ -66,7 +67,8 @@ def _fail_closed(exc: Exception) -> ScanResult:
                 evidence=f"Guard failed: {type(exc).__name__}",
             )
         ],
-        latency_ms=0.0,
+        latency_ms=latency_ms,
+        stages_run=["error"],
     )
 
 
@@ -629,6 +631,7 @@ class Guard:
         isolated: bool = False,
     ) -> ScanResult:
         """Scan output from a ScanRequest (hosted server or local pipeline)."""
+        start = time.perf_counter()
         violation = self._limits.check_input_length(request.text)
         if violation is not None:
             return _limit_result(violation, len(request.text))
@@ -644,7 +647,7 @@ class Guard:
                 return result
         except Exception as exc:
             _log.error("guard.scan_output_request failed: %s", exc)
-            return _fail_closed(exc)
+            return _fail_closed(exc, (time.perf_counter() - start) * 1000)
 
     def check_tool_call(
         self,
@@ -655,6 +658,7 @@ class Guard:
         approved: bool | None = None,
     ) -> ScanResult:
         """Check a proposed tool call for destructive, taint, and financial risks."""
+        start = time.perf_counter()
         _ = approved  # resume-only via ApprovalProvider; caller flag is ignored
         if not self._limits.is_tool_allowed(tool_name):
             return _limit_result(
@@ -703,7 +707,7 @@ class Guard:
                 return result
         except Exception as exc:
             _log.error("guard.check_tool_call failed: %s", exc)
-            return _fail_closed(exc)
+            return _fail_closed(exc, (time.perf_counter() - start) * 1000)
 
     def scan_request(
         self,
@@ -712,6 +716,7 @@ class Guard:
         isolated: bool = False,
     ) -> ScanResult:
         """Scan from a ScanRequest object."""
+        start = time.perf_counter()
         violation = self._limits.check_input_length(request.text)
         if violation is not None:
             return _limit_result(violation, len(request.text))
@@ -744,7 +749,7 @@ class Guard:
             raise
         except Exception as exc:
             _log.error("guard.scan_request failed: %s", exc)
-            return _fail_closed(exc)
+            return _fail_closed(exc, (time.perf_counter() - start) * 1000)
 
     @property
     def is_server_mode(self) -> bool:

--- a/sdk/src/unplug/guard.py
+++ b/sdk/src/unplug/guard.py
@@ -631,7 +631,7 @@ class Guard:
         isolated: bool = False,
     ) -> ScanResult:
         """Scan output from a ScanRequest (hosted server or local pipeline)."""
-        start = time.perf_counter()
+        start_time = time.perf_counter()
         violation = self._limits.check_input_length(request.text)
         if violation is not None:
             return _limit_result(violation, len(request.text))
@@ -647,7 +647,8 @@ class Guard:
                 return result
         except Exception as exc:
             _log.error("guard.scan_output_request failed: %s", exc)
-            return _fail_closed(exc, (time.perf_counter() - start) * 1000)
+            latency_ms = (time.perf_counter() - start_time) * 1000
+            return _fail_closed(exc, latency_ms)
 
     def check_tool_call(
         self,
@@ -658,7 +659,7 @@ class Guard:
         approved: bool | None = None,
     ) -> ScanResult:
         """Check a proposed tool call for destructive, taint, and financial risks."""
-        start = time.perf_counter()
+        start_time = time.perf_counter()
         _ = approved  # resume-only via ApprovalProvider; caller flag is ignored
         if not self._limits.is_tool_allowed(tool_name):
             return _limit_result(
@@ -707,7 +708,8 @@ class Guard:
                 return result
         except Exception as exc:
             _log.error("guard.check_tool_call failed: %s", exc)
-            return _fail_closed(exc, (time.perf_counter() - start) * 1000)
+            latency_ms = (time.perf_counter() - start_time) * 1000
+            return _fail_closed(exc, latency_ms)
 
     def scan_request(
         self,
@@ -716,7 +718,7 @@ class Guard:
         isolated: bool = False,
     ) -> ScanResult:
         """Scan from a ScanRequest object."""
-        start = time.perf_counter()
+        start_time = time.perf_counter()
         violation = self._limits.check_input_length(request.text)
         if violation is not None:
             return _limit_result(violation, len(request.text))
@@ -749,7 +751,8 @@ class Guard:
             raise
         except Exception as exc:
             _log.error("guard.scan_request failed: %s", exc)
-            return _fail_closed(exc, (time.perf_counter() - start) * 1000)
+            latency_ms = (time.perf_counter() - start_time) * 1000
+            return _fail_closed(exc, latency_ms)
 
     @property
     def is_server_mode(self) -> bool:

--- a/sdk/tests/unit/scanners/test_error_handling.py
+++ b/sdk/tests/unit/scanners/test_error_handling.py
@@ -56,25 +56,36 @@ class TestPipelineFailClosed:
 
 
 class TestGuardFailClosed:
+    def _delayed_raise(self, *args, **kwargs):
+        import time
+        time.sleep(0.01)
+        raise RuntimeError("fatal")
+
     def test_scan_error_returns_blocked(self):
         guard = Guard(scanners=["injection"])
-        with patch.object(guard._input_pipeline, "run", side_effect=RuntimeError("fatal")):
+        with patch.object(guard._input_pipeline, "run", side_effect=self._delayed_raise):
             result = guard.scan("test")
         assert result.safe is False
         assert result.action == Action.BLOCK
         assert result.findings[0].subcategory == "guard_error"
         assert "RuntimeError" in result.findings[0].evidence
+        assert result.stages_run == ["error"]
+        assert result.latency_ms > 0.0
 
     def test_scan_output_error_returns_blocked(self):
         guard = Guard(scanners=["injection"])
-        with patch.object(guard._output_pipeline, "run", side_effect=RuntimeError("fatal")):
+        with patch.object(guard._output_pipeline, "run", side_effect=self._delayed_raise):
             result = guard.scan_output("test")
         assert result.safe is False
         assert result.action == Action.BLOCK
+        assert result.stages_run == ["error"]
+        assert result.latency_ms > 0.0
 
     def test_check_tool_call_error_returns_blocked(self):
         guard = Guard(scanners=["injection"])
-        with patch.object(guard._tool_pipeline, "run", side_effect=RuntimeError("fatal")):
+        with patch.object(guard._tool_pipeline, "run", side_effect=self._delayed_raise):
             result = guard.check_tool_call("rm", {"-rf": "/"})
         assert result.safe is False
         assert result.action == Action.BLOCK
+        assert result.stages_run == ["error"]
+        assert result.latency_ms > 0.0

--- a/sdk/tests/unit/test_fail_closed_deprecation.py
+++ b/sdk/tests/unit/test_fail_closed_deprecation.py
@@ -29,6 +29,17 @@ def test_guard_error_still_blocks() -> None:
     assert not result.safe
 
 
+def test_guard_error_reports_error_stage() -> None:
+    guard = Guard()
+    with patch.object(guard._input_pipeline, "run", side_effect=RuntimeError("boom")):
+        result = guard.scan("hello")
+    assert result.action == Action.BLOCK
+    assert not result.safe
+    assert result.stages_run == ["error"]
+    assert result.findings[0].stage == "error"
+    assert result.latency_ms >= 0.0
+
+
 def test_fail_mode_open_warns() -> None:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")


### PR DESCRIPTION
Closes #106

## Problem
`_fail_closed` hardcoded `latency_ms=0.0` and left `stages_run` empty, so a scan that BLOCKed due to an internal error was indistinguishable from an instant block in logs and metrics - even though its Finding already had `stage="error"`.

## Change
- `_fail_closed` now sets `stages_run=["error"]` and accepts a latency value.
- `scan_request`, `scan_output_request`, and `check_tool_call` record a `time.perf_counter()` start and thread the elapsed ms through.
- Added `test_guard_error_reports_error_stage` pinning stage + latency.

## Verification
`ruff check`, `ruff format --check`, `mypy`, `pytest tests/unit` (680 passed) and `pytest tests/security` (178 passed) all pass locally.

## AI assistance
Implemented with AI coding-assistant help (per AI_POLICY.md); I reviewed and understand every change.