### PR TITLE
give every test an empty model cache by default

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -250,6 +250,7 @@ markers = [
     "requires_yara: tests needing yara-python extra",
     "requires_ml: tests needing ML stack extra",
     "requires_integrations: tests needing agent framework extras",
+    "real_model_cache: opts out of the empty-UNPLUG_MODEL_CACHE isolation fixture",
     "slow: wall-clock stress tests; excluded from the default/PR gate, run via the nightly slow-stress workflow or `make test-slow`",
 ]
 filterwarnings = [

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -73,6 +73,15 @@ def _isolate_model_cache(
         return
     empty = tmp_path_factory.mktemp("empty_model_cache")
     monkeypatch.setenv("UNPLUG_MODEL_CACHE", str(empty))
+    # The cache variable alone is not isolation. resolve_spec_path prefers
+    # UNPLUG_MODEL_PATH over the cache entirely, so a developer with one exported
+    # (or a module fixture that sets it and never tears it down) still reaches a
+    # real checkpoint and the empty cache above measures nothing.
+    #
+    # UNPLUG_TEST_CHECKPOINT is deliberately left alone. It is the harness's own
+    # way of pointing the encoding probes and ML validation at a checkpoint, so
+    # clearing it does not close a hole, it just turns those tests off.
+    monkeypatch.delenv("UNPLUG_MODEL_PATH", raising=False)
 
 
 @pytest.fixture(scope="session")

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -55,6 +55,26 @@ def _docker_e2e_enabled() -> bool:
     return os.environ.get("RUN_DOCKER_E2E", "").strip() in {"1", "true", "yes"}
 
 
+@pytest.fixture(autouse=True)
+def _isolate_model_cache(
+    tmp_path_factory: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    """Point UNPLUG_MODEL_CACHE at an empty directory for every test.
+
+    Without this the suite reads whatever is in the developer's real
+    ~/.cache/unplug/models, so cache-dependent behaviour passes on CI (empty
+    cache) and fails locally, or the reverse. Tests that want a populated cache
+    build one under tmp_path and set the variable themselves; tests that need
+    the machine cache opt out with @pytest.mark.real_model_cache (#163).
+    """
+    if request.node.get_closest_marker("real_model_cache") is not None:
+        return
+    empty = tmp_path_factory.mktemp("empty_model_cache")
+    monkeypatch.setenv("UNPLUG_MODEL_CACHE", str(empty))
+
+
 @pytest.fixture(scope="session")
 def ml_checkpoint() -> Path:
     path = resolve_validation_checkpoint(require_weights=False)

--- a/sdk/tests/integration/test_audit.py
+++ b/sdk/tests/integration/test_audit.py
@@ -11,6 +11,11 @@ from unplug.audit.boundary import default_boundary_probes_path, run_boundary_pro
 from unplug.audit.runner import run_audit
 from unplug.ml.validation import resolve_validation_checkpoint
 
+# These modules gate on resolve_validation_checkpoint(), which reads the machine
+# model cache at import time via skipif. They opt out of the empty-cache isolation
+# fixture so the skip decision and the test body see the same cache (#163).
+pytestmark = pytest.mark.real_model_cache
+
 WORKSPACE = Path(__file__).resolve().parents[4]
 
 

--- a/sdk/tests/integration/test_audit.py
+++ b/sdk/tests/integration/test_audit.py
@@ -11,10 +11,10 @@ from unplug.audit.boundary import default_boundary_probes_path, run_boundary_pro
 from unplug.audit.runner import run_audit
 from unplug.ml.validation import resolve_validation_checkpoint
 
-# These modules gate on resolve_validation_checkpoint(), which reads the machine
-# model cache at import time via skipif. They opt out of the empty-cache isolation
-# fixture so the skip decision and the test body see the same cache (#163).
-pytestmark = pytest.mark.real_model_cache
+# Only the one test below gates on resolve_validation_checkpoint(), whose skipif
+# is evaluated at import time against the machine cache. Opting the whole module
+# out let tests that never touch a checkpoint read the machine cache too, which
+# is the machine-dependence this fixture exists to remove (#163).
 
 WORKSPACE = Path(__file__).resolve().parents[4]
 
@@ -46,6 +46,9 @@ def test_run_audit_ml_checks_split() -> None:
     assert {"ml_checkpoint", "ml_configured", "ml_active"}.issubset(names)
 
 
+# Opts out of the empty-cache fixture so the import-time skip decision and the
+# test body see the same cache.
+@pytest.mark.real_model_cache
 @pytest.mark.skipif(_checkpoint() is None, reason="checkpoint not available")
 def test_run_audit_path_only_wires_ml() -> None:
     pytest.importorskip("torch")
@@ -98,6 +101,7 @@ def test_run_audit_ml_probes_skipped_mark_not_passed() -> None:
     assert report["wiring_pass"] is True
 
 
+@pytest.mark.real_model_cache
 @pytest.mark.skipif(_checkpoint() is None, reason="checkpoint not available")
 def test_run_audit_require_ml_wires_injection() -> None:
     pytest.importorskip("torch")
@@ -124,6 +128,7 @@ def test_run_audit_require_ml_wires_injection() -> None:
             os.environ["UNPLUG_MODEL_PATH"] = prev_path
 
 
+@pytest.mark.real_model_cache
 @pytest.mark.skipif(_checkpoint() is None, reason="checkpoint not available")
 def test_run_audit_probes_with_require_ml() -> None:
     pytest.importorskip("torch")

--- a/sdk/tests/integration/test_guard_ml.py
+++ b/sdk/tests/integration/test_guard_ml.py
@@ -11,10 +11,9 @@ from unplug.ml.spans_merge import merge_char_spans
 from unplug.ml.types import CharSpan
 from unplug.ml.validation import resolve_validation_checkpoint
 
-# These modules gate on resolve_validation_checkpoint(), which reads the machine
-# model cache at import time via skipif. They opt out of the empty-cache isolation
-# fixture so the skip decision and the test body see the same cache (#163).
-pytestmark = pytest.mark.real_model_cache
+# Only the tests whose import-time skipif reads the machine cache opt out. A
+# module-level mark opted out tests that never touch a checkpoint too, which is
+# the machine-dependence the isolation fixture exists to remove (#163).
 
 
 def test_merge_char_spans_overlapping() -> None:
@@ -34,6 +33,7 @@ def _checkpoint() -> Path | None:
     return resolve_validation_checkpoint(require_weights=False)
 
 
+@pytest.mark.real_model_cache
 @pytest.mark.skipif(_checkpoint() is None, reason="checkpoint not available")
 def test_guard_active_model_wires_injection_ml() -> None:
     torch = pytest.importorskip("torch")
@@ -93,6 +93,7 @@ def test_with_tiny_is_deprecated_but_equivalent() -> None:
     assert legacy.config.model_dump() == current.config.model_dump()
 
 
+@pytest.mark.real_model_cache
 @pytest.mark.skipif(_checkpoint() is None, reason="checkpoint not available")
 def test_recall_gate_rescues_regex_missed_injection() -> None:
     torch = pytest.importorskip("torch")

--- a/sdk/tests/integration/test_guard_ml.py
+++ b/sdk/tests/integration/test_guard_ml.py
@@ -11,6 +11,11 @@ from unplug.ml.spans_merge import merge_char_spans
 from unplug.ml.types import CharSpan
 from unplug.ml.validation import resolve_validation_checkpoint
 
+# These modules gate on resolve_validation_checkpoint(), which reads the machine
+# model cache at import time via skipif. They opt out of the empty-cache isolation
+# fixture so the skip decision and the test body see the same cache (#163).
+pytestmark = pytest.mark.real_model_cache
+
 
 def test_merge_char_spans_overlapping() -> None:
     spans = [

--- a/sdk/tests/integration/test_ml_integration.py
+++ b/sdk/tests/integration/test_ml_integration.py
@@ -15,7 +15,11 @@ from unplug.core.context import ExecutionContext
 from unplug.core.taint import TaintedText, TrustLevel
 from unplug.ml.head_tail import should_use_head_tail
 
-pytestmark = pytest.mark.requires_ml_weights
+# real_model_cache as well as requires_ml_weights: the module fixtures below read
+# the session ml_checkpoint fixtures, which resolve before the function-scoped
+# isolation fixture runs. Without the mark the collection-time skip decision and
+# the fixture setup disagree about which cache they are looking at.
+pytestmark = [pytest.mark.requires_ml_weights, pytest.mark.real_model_cache]
 
 PROBE_FILE = (
     Path(__file__).resolve().parents[2]

--- a/sdk/tests/unit/core/normalize/test_encoding_probes.py
+++ b/sdk/tests/unit/core/normalize/test_encoding_probes.py
@@ -21,10 +21,9 @@ from unplug.core.normalize.encodings import (
 from unplug.core.runtime.model_runtime import load_active_model_provider
 from unplug.ml.validation import resolve_validation_checkpoint
 
-# These modules gate on resolve_validation_checkpoint(), which reads the machine
-# model cache at import time via skipif. They opt out of the empty-cache isolation
-# fixture so the skip decision and the test body see the same cache (#163).
-pytestmark = pytest.mark.real_model_cache
+# Only the tests whose import-time skipif reads the machine cache opt out. A
+# module-level mark opted out tests that never touch a checkpoint too, which is
+# the machine-dependence the isolation fixture exists to remove (#163).
 
 ROOT = Path(__file__).resolve().parents[4]
 PROBES = ROOT / "src/unplug/audit/data/encoding_probe_queries.json"
@@ -89,6 +88,7 @@ class TestHeuristicEncodingProbes:
         assert scan_encoding_blobs(text) == []
 
 
+@pytest.mark.real_model_cache
 @pytest.mark.skipif(_checkpoint() is None, reason="checkpoint not available")
 class TestSpanModelEncodingProbes:
     @pytest.fixture
@@ -133,6 +133,7 @@ class TestSpanModelEncodingProbes:
         assert findings
 
 
+@pytest.mark.real_model_cache
 @pytest.mark.skipif(_checkpoint() is None, reason="checkpoint not available")
 class TestGuardEncodingIntegration:
     @pytest.fixture

--- a/sdk/tests/unit/core/normalize/test_encoding_probes.py
+++ b/sdk/tests/unit/core/normalize/test_encoding_probes.py
@@ -21,6 +21,11 @@ from unplug.core.normalize.encodings import (
 from unplug.core.runtime.model_runtime import load_active_model_provider
 from unplug.ml.validation import resolve_validation_checkpoint
 
+# These modules gate on resolve_validation_checkpoint(), which reads the machine
+# model cache at import time via skipif. They opt out of the empty-cache isolation
+# fixture so the skip decision and the test body see the same cache (#163).
+pytestmark = pytest.mark.real_model_cache
+
 ROOT = Path(__file__).resolve().parents[4]
 PROBES = ROOT / "src/unplug/audit/data/encoding_probe_queries.json"
 

--- a/sdk/tests/unit/core/normalize/test_encodings.py
+++ b/sdk/tests/unit/core/normalize/test_encodings.py
@@ -21,6 +21,11 @@ from unplug.ml.validation import resolve_validation_checkpoint
 from unplug.pipelines.input import InputPipeline
 from unplug.scanners.injection import InjectionScanner
 
+# These modules gate on resolve_validation_checkpoint(), which reads the machine
+# model cache at import time via skipif. They opt out of the empty-cache isolation
+# fixture so the skip decision and the test body see the same cache (#163).
+pytestmark = pytest.mark.real_model_cache
+
 
 def _b64(text: str) -> str:
     return base64.b64encode(text.encode()).decode()

--- a/sdk/tests/unit/core/normalize/test_encodings.py
+++ b/sdk/tests/unit/core/normalize/test_encodings.py
@@ -21,10 +21,9 @@ from unplug.ml.validation import resolve_validation_checkpoint
 from unplug.pipelines.input import InputPipeline
 from unplug.scanners.injection import InjectionScanner
 
-# These modules gate on resolve_validation_checkpoint(), which reads the machine
-# model cache at import time via skipif. They opt out of the empty-cache isolation
-# fixture so the skip decision and the test body see the same cache (#163).
-pytestmark = pytest.mark.real_model_cache
+# Only the tests whose import-time skipif reads the machine cache opt out. A
+# module-level mark opted out tests that never touch a checkpoint too, which is
+# the machine-dependence the isolation fixture exists to remove (#163).
 
 
 def _b64(text: str) -> str:
@@ -114,6 +113,7 @@ class TestEncodingClassifiers:
         assert sub == "first"
         assert len(calls) == 1
 
+    @pytest.mark.real_model_cache
     @pytest.mark.skipif(_checkpoint() is None, reason="checkpoint not available")
     def test_span_model_classifier_on_decoded(self) -> None:
         pytest.importorskip("torch")


### PR DESCRIPTION
Closes #163.

Every test now runs with `UNPLUG_MODEL_CACHE` pointed at an empty directory, so the suite stops reading whatever the developer happens to have in `~/.cache/unplug/models`. That divergence is why `test_guard_survives_corrupt_checkpoint` passed on CI and failed locally.

Four modules gate on `resolve_validation_checkpoint()` inside a module-level `skipif`, which is evaluated at import time, before any fixture runs. Blanking the cache underneath them makes the skip decision and the test body disagree, so they opt out with a new `real_model_cache` marker. That does not make them less vacuous on a runner with no weights, it just says so where someone will see it.

Worth pairing with #149, whose branch adds tests that build their own populated cache. Determinism here, coverage there.

```
1252 passed, 3 skipped, 30 deselected
```
