### PR TITLE
classify MCP and CamelCase tool names

### DIFF
--- a/docs/AGENT_ACTIONS.md
+++ b/docs/AGENT_ACTIONS.md
@@ -68,6 +68,38 @@ else:
 
 For batch/cron agents, **never** auto-approve: use a provider that returns `False` unless an operator explicitly signed off (see [`HERMES_AGENT_SECURITY.md`](HERMES_AGENT_SECURITY.md)).
 
+## How tools are classified
+
+The taint gate needs to know which of your tools can cause an effect in the world and
+which only read. Names are normalized before matching, so `WebFetch`, `web_fetch`,
+`mcp__browser__webFetch` and `browser.web-fetch` all resolve to the same thing. Both
+camelCase and the MCP `server__tool` convention are handled, and vendor prefixes are
+matched through, so `slack_post_message` is recognised as a post.
+
+A name that matches nothing is treated as a side effect while the session is tainted,
+and is allowed on a clean session. That is deliberate: an unrecognised name is not
+evidence a call is safe, and the failure it guards against is silent.
+
+Four knobs, all under `[tools]` in `unplug.toml`:
+
+```toml
+[tools]
+# Names you want classified explicitly. These win over the patterns.
+side_effect_tools = ["deploy_to_prod", "mcp__acme__charge_card"]
+taint_source_tools = ["mcp__acme__fetch_ticket"]
+read_only_tools = ["mcp__acme__frobnicate"]
+
+# Or add to the regexes, which match against the normalized name and each of its
+# underscore-delimited suffixes.
+side_effect_patterns = ["^deploy", "^charge"]
+
+# Set false to allow tool names that match nothing, even on a tainted session.
+unknown_tool_is_side_effect = false
+```
+
+If you see `session_taint_unknown_tool` findings for a tool that genuinely only reads,
+add it to `read_only_tools` rather than turning the gate off.
+
 ## Integration adapter pattern
 
 Replace bare `raise RuntimeError` on every `not decision.allowed` with action-aware handling:

--- a/sdk/src/unplug/config/tools.py
+++ b/sdk/src/unplug/config/tools.py
@@ -45,19 +45,37 @@ def _compile(patterns: tuple[str, ...]) -> list[re.Pattern[str]]:
 
 
 def _matches_token(rx: re.Pattern[str], variant: str) -> bool:
-    """True when rx matches whole underscore tokens of variant, not part of one.
+    """True when rx's match ends where an underscore token ends.
 
-    The patterns are verb prefixes (^pay, ^post, ^rm, ^exec). Matching them against
-    a bare suffix means a prefix of a longer word counts: ^pay hits payload, ^post
-    hits postgres and postcode, ^rm hits rma. Those are read tools, and classifying
-    them as side effects denies them under the readonly profile. Requiring the match
-    to end where a token ends keeps ^delete on delete_file and drops ^pay on payload.
+    Applied only to the trimmed suffixes, never to the whole name. See _any_match.
     """
     return any(m.end() == len(variant) or variant[m.end()] == "_" for m in rx.finditer(variant))
 
 
 def _any_match(regexes: list[re.Pattern[str]], variants: tuple[str, ...]) -> bool:
-    return any(_matches_token(rx, v) for rx in regexes for v in variants)
+    """Match the full name loosely and the trimmed suffixes strictly.
+
+    The patterns are verb stems, so a prefix match on the name the caller actually
+    passed is intended: ^exec is meant to catch execute and execute_command, ^rm to
+    catch rmdir. Requiring those to land on a token boundary silently unclassified
+    822 names this repo used to treat as side effects, and let the messaging profile
+    through on `execute`.
+
+    The false positives come from the other direction. _name_variants trims leading
+    segments so a vendor prefix cannot hide the verb, and testing a verb stem against
+    a bare trimmed suffix is what made ^pay match payload and ^post match postgres.
+    Nothing was asking about a tool called `payload`; that string only exists because
+    `get_payload` was trimmed. So the suffixes, and only the suffixes, have to match
+    a whole token.
+
+    variants[0] is the full normalized name and the rest are its trimmed suffixes.
+    """
+    if not variants:
+        return False
+    whole, suffixes = variants[0], variants[1:]
+    if any(rx.search(whole) for rx in regexes):
+        return True
+    return any(_matches_token(rx, s) for rx in regexes for s in suffixes)
 
 
 # Splits camelCase and PascalCase at the boundary, so WebFetch becomes web_fetch

--- a/sdk/src/unplug/config/tools.py
+++ b/sdk/src/unplug/config/tools.py
@@ -122,6 +122,31 @@ def _name_variants(tool_name: str) -> tuple[str, ...]:
     return tuple("_".join(parts[i:]) for i in range(len(parts)))
 
 
+def _namespace_variants(tool_name: str) -> tuple[str, ...]:
+    """The normalized name, plus itself with leading NAMESPACE segments dropped.
+
+    For the explicit `side_effect_tools` / `read_only_tools` lists, not the
+    patterns. An entry there names one tool, and _name_variants trims on every
+    underscore, so `read_only_tools = ["frobnicate"]` also matched
+    `admin_frobnicate` and `evil_frobnicate`: a read-only grant is an exemption
+    from the unknown-tool review, and it was being handed to any tool that
+    happened to end in the granted word.
+
+    Trimming only where a namespace separator was still keeps the case the lists
+    exist for, a host prefixing its own name: `send_message` matches an incoming
+    `mcp__slack__send_message`, because that prefix came from `__`. It does not
+    match `admin_send_message`, because that is a different tool's name.
+    """
+    name = tool_name.strip()
+    segments = [s for s in _SEPARATOR_SPLIT.split(name) if s]
+    out: list[str] = []
+    for i in range(len(segments)):
+        norm = _normalize_tool_name("_".join(segments[i:]))
+        if norm:
+            out.append(norm)
+    return tuple(dict.fromkeys(out))
+
+
 def resolve_profile(name: str | None) -> ToolProfile | None:
     if not name:
         return None
@@ -193,14 +218,14 @@ class ToolPolicyConfig(BaseModel):
     def is_side_effect(self, tool_name: str) -> bool:
         variants = _name_variants(tool_name)
         configured = {_normalize_tool_name(t) for t in self.side_effect_tools}
-        if configured.intersection(variants):
+        if configured.intersection(_namespace_variants(tool_name)):
             return True
         return _any_match(self._side_effect_regexes(), variants)
 
     def is_taint_source(self, tool_name: str) -> bool:
         variants = _name_variants(tool_name)
         configured = {_normalize_tool_name(t) for t in self.taint_source_tools}
-        if configured.intersection(variants):
+        if configured.intersection(_namespace_variants(tool_name)):
             return True
         return _any_match(self._taint_source_regexes(), variants)
 
@@ -214,7 +239,7 @@ class ToolPolicyConfig(BaseModel):
         """Positively recognised as having no side effect, rather than merely unmatched."""
         variants = _name_variants(tool_name)
         configured = {_normalize_tool_name(t) for t in self.read_only_tools}
-        if configured.intersection(variants):
+        if configured.intersection(_namespace_variants(tool_name)):
             return True
         if _any_match(self._taint_source_regexes(), variants):
             return True

--- a/sdk/src/unplug/config/tools.py
+++ b/sdk/src/unplug/config/tools.py
@@ -36,6 +36,7 @@ def _build_profile_pattern_maps() -> tuple[
 _tool_maps = load_tool_patterns_map()
 DEFAULT_SIDE_EFFECT_PATTERNS = _tool_maps.side_effect
 DEFAULT_TAINT_SOURCE_PATTERNS = _tool_maps.taint_source
+DEFAULT_READ_ONLY_PATTERNS = _tool_maps.read_only
 PROFILE_BLOCKED_PATTERNS, PROFILE_ALLOWED_PATTERNS = _build_profile_pattern_maps()
 
 
@@ -43,13 +44,39 @@ def _compile(patterns: tuple[str, ...]) -> list[re.Pattern[str]]:
     return [re.compile(p, re.IGNORECASE) for p in patterns]
 
 
+# Splits camelCase and PascalCase at the boundary, so WebFetch becomes web_fetch
+# and sendEmail becomes send_email. The second alternative handles runs of capitals
+# followed by a word, as in HTTPPost -> http_post.
+_CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+
+# Namespace separators, longest first. MCP uses mcp__server__tool; agent hosts use
+# server:tool or server.tool. The host is not what decides whether a call has side
+# effects, so only the last segment is kept.
+_NAMESPACE_SEPARATORS = ("__", ":", ".", "/")
+
+
 def _normalize_tool_name(tool_name: str) -> str:
-    name = tool_name.strip().lower()
-    if ":" in name:
-        name = name.split(":")[-1]
-    if "." in name:
-        name = name.split(".")[-1]
-    return name
+    name = tool_name.strip()
+    for separator in _NAMESPACE_SEPARATORS:
+        if separator in name:
+            name = name.split(separator)[-1]
+    name = _CAMEL_BOUNDARY.sub("_", name)
+    return name.replace("-", "_").strip("_").lower()
+
+
+def _name_variants(tool_name: str) -> tuple[str, ...]:
+    """The normalized name plus each of its underscore-delimited suffixes.
+
+    Classification patterns are anchored at the start, which misses the very common
+    vendor-prefixed shape: slack_post_message and github_create_issue are a post and
+    a create, but neither starts with one. Matching every suffix as well means the
+    verb is found wherever the vendor chose to put it (#166).
+    """
+    norm = _normalize_tool_name(tool_name)
+    if not norm:
+        return ()
+    parts = norm.split("_")
+    return tuple("_".join(parts[i:]) for i in range(len(parts)))
 
 
 def resolve_profile(name: str | None) -> ToolProfile | None:
@@ -66,15 +93,15 @@ def resolve_profile(name: str | None) -> ToolProfile | None:
 def is_tool_permitted_by_profile(tool_name: str, profile: ToolProfile | None) -> bool:
     if profile is None or profile is ToolProfile.FULL:
         return True
-    norm = _normalize_tool_name(tool_name)
+    variants = _name_variants(tool_name)
     blocked = _compile(PROFILE_BLOCKED_PATTERNS.get(profile, ()))
-    if any(rx.search(norm) for rx in blocked):
+    if any(rx.search(v) for rx in blocked for v in variants):
         return False
     allowed_patterns = PROFILE_ALLOWED_PATTERNS.get(profile)
     if allowed_patterns is None:
         return True
     allowed = _compile(allowed_patterns)
-    return any(rx.search(norm) for rx in allowed)
+    return any(rx.search(v) for rx in allowed for v in variants)
 
 
 class ToolPolicyConfig(BaseModel):
@@ -91,6 +118,17 @@ class ToolPolicyConfig(BaseModel):
 
     taint_source_patterns: tuple[str, ...] = DEFAULT_TAINT_SOURCE_PATTERNS
     taint_source_tools: tuple[str, ...] = Field(default_factory=tuple)
+
+    read_only_patterns: tuple[str, ...] = DEFAULT_READ_ONLY_PATTERNS
+    read_only_tools: tuple[str, ...] = Field(default_factory=tuple)
+
+    unknown_tool_is_side_effect: bool = Field(
+        default=True,
+        description=(
+            "Hold a tool whose name matches nothing known for review while the session "
+            "is tainted. Set false to restore the pre-#166 behaviour of allowing it."
+        ),
+    )
 
     profile: str | None = Field(
         default=None,
@@ -110,16 +148,35 @@ class ToolPolicyConfig(BaseModel):
         return _compile(self.taint_source_patterns)
 
     def is_side_effect(self, tool_name: str) -> bool:
-        norm = _normalize_tool_name(tool_name)
-        if norm in {t.lower() for t in self.side_effect_tools}:
+        variants = _name_variants(tool_name)
+        configured = {_normalize_tool_name(t) for t in self.side_effect_tools}
+        if configured.intersection(variants):
             return True
-        return any(rx.search(norm) for rx in self._side_effect_regexes())
+        return any(rx.search(v) for rx in self._side_effect_regexes() for v in variants)
 
     def is_taint_source(self, tool_name: str) -> bool:
-        norm = _normalize_tool_name(tool_name)
-        if norm in {t.lower() for t in self.taint_source_tools}:
+        variants = _name_variants(tool_name)
+        configured = {_normalize_tool_name(t) for t in self.taint_source_tools}
+        if configured.intersection(variants):
             return True
-        return any(rx.search(norm) for rx in self._taint_source_regexes())
+        return any(rx.search(v) for rx in self._taint_source_regexes() for v in variants)
+
+    def _read_only_regexes(self) -> list[re.Pattern[str]]:
+        return _compile(self.read_only_patterns)
 
     def is_read_only(self, tool_name: str) -> bool:
         return not self.is_side_effect(tool_name)
+
+    def is_known_read_only(self, tool_name: str) -> bool:
+        """Positively recognised as having no side effect, rather than merely unmatched."""
+        variants = _name_variants(tool_name)
+        configured = {_normalize_tool_name(t) for t in self.read_only_tools}
+        if configured.intersection(variants):
+            return True
+        if any(rx.search(v) for rx in self._taint_source_regexes() for v in variants):
+            return True
+        return any(rx.search(v) for rx in self._read_only_regexes() for v in variants)
+
+    def is_unclassified(self, tool_name: str) -> bool:
+        """Matches none of the side-effect, taint-source, or read-only tables."""
+        return not self.is_side_effect(tool_name) and not self.is_known_read_only(tool_name)

--- a/sdk/src/unplug/config/tools.py
+++ b/sdk/src/unplug/config/tools.py
@@ -44,22 +44,47 @@ def _compile(patterns: tuple[str, ...]) -> list[re.Pattern[str]]:
     return [re.compile(p, re.IGNORECASE) for p in patterns]
 
 
+def _matches_token(rx: re.Pattern[str], variant: str) -> bool:
+    """True when rx matches whole underscore tokens of variant, not part of one.
+
+    The patterns are verb prefixes (^pay, ^post, ^rm, ^exec). Matching them against
+    a bare suffix means a prefix of a longer word counts: ^pay hits payload, ^post
+    hits postgres and postcode, ^rm hits rma. Those are read tools, and classifying
+    them as side effects denies them under the readonly profile. Requiring the match
+    to end where a token ends keeps ^delete on delete_file and drops ^pay on payload.
+    """
+    return any(m.end() == len(variant) or variant[m.end()] == "_" for m in rx.finditer(variant))
+
+
+def _any_match(regexes: list[re.Pattern[str]], variants: tuple[str, ...]) -> bool:
+    return any(_matches_token(rx, v) for rx in regexes for v in variants)
+
+
 # Splits camelCase and PascalCase at the boundary, so WebFetch becomes web_fetch
 # and sendEmail becomes send_email. The second alternative handles runs of capitals
 # followed by a word, as in HTTPPost -> http_post.
 _CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
 
 # Namespace separators, longest first. MCP uses mcp__server__tool; agent hosts use
-# server:tool or server.tool. The host is not what decides whether a call has side
-# effects, so only the last segment is kept.
+# server:tool or server.tool.
 _NAMESPACE_SEPARATORS = ("__", ":", ".", "/")
+_SEPARATOR_SPLIT = re.compile("|".join(re.escape(s) for s in _NAMESPACE_SEPARATORS))
 
 
 def _normalize_tool_name(tool_name: str) -> str:
+    """Flatten a namespaced or camelCase tool name to underscore-delimited tokens.
+
+    Every segment is kept, not just the last one. Keeping only the last segment
+    dropped the verb whenever a host put it first (delete.file, exec.command,
+    server/delete/user all became a harmless-looking noun) and produced the empty
+    string for a trailing separator, which classified as nothing at all. The host
+    prefix is still not what decides whether a call has side effects, but it does
+    not need to be discarded here: _name_variants walks the suffixes, so the verb
+    is found wherever in the name it sits.
+    """
     name = tool_name.strip()
-    for separator in _NAMESPACE_SEPARATORS:
-        if separator in name:
-            name = name.split(separator)[-1]
+    segments = [s for s in _SEPARATOR_SPLIT.split(name) if s]
+    name = "_".join(segments)
     name = _CAMEL_BOUNDARY.sub("_", name)
     return name.replace("-", "_").strip("_").lower()
 
@@ -95,13 +120,13 @@ def is_tool_permitted_by_profile(tool_name: str, profile: ToolProfile | None) ->
         return True
     variants = _name_variants(tool_name)
     blocked = _compile(PROFILE_BLOCKED_PATTERNS.get(profile, ()))
-    if any(rx.search(v) for rx in blocked for v in variants):
+    if _any_match(blocked, variants):
         return False
     allowed_patterns = PROFILE_ALLOWED_PATTERNS.get(profile)
     if allowed_patterns is None:
         return True
     allowed = _compile(allowed_patterns)
-    return any(rx.search(v) for rx in allowed for v in variants)
+    return _any_match(allowed, variants)
 
 
 class ToolPolicyConfig(BaseModel):
@@ -152,14 +177,14 @@ class ToolPolicyConfig(BaseModel):
         configured = {_normalize_tool_name(t) for t in self.side_effect_tools}
         if configured.intersection(variants):
             return True
-        return any(rx.search(v) for rx in self._side_effect_regexes() for v in variants)
+        return _any_match(self._side_effect_regexes(), variants)
 
     def is_taint_source(self, tool_name: str) -> bool:
         variants = _name_variants(tool_name)
         configured = {_normalize_tool_name(t) for t in self.taint_source_tools}
         if configured.intersection(variants):
             return True
-        return any(rx.search(v) for rx in self._taint_source_regexes() for v in variants)
+        return _any_match(self._taint_source_regexes(), variants)
 
     def _read_only_regexes(self) -> list[re.Pattern[str]]:
         return _compile(self.read_only_patterns)
@@ -173,9 +198,9 @@ class ToolPolicyConfig(BaseModel):
         configured = {_normalize_tool_name(t) for t in self.read_only_tools}
         if configured.intersection(variants):
             return True
-        if any(rx.search(v) for rx in self._taint_source_regexes() for v in variants):
+        if _any_match(self._taint_source_regexes(), variants):
             return True
-        return any(rx.search(v) for rx in self._read_only_regexes() for v in variants)
+        return _any_match(self._read_only_regexes(), variants)
 
     def is_unclassified(self, tool_name: str) -> bool:
         """Matches none of the side-effect, taint-source, or read-only tables."""

--- a/sdk/src/unplug/data/maps/tool_patterns.toml
+++ b/sdk/src/unplug/data/maps/tool_patterns.toml
@@ -20,6 +20,17 @@ patterns = [
   "^send_email",
   "^post_message",
   "^message_send",
+  "^send",
+  "^post",
+  "^publish",
+  "^upload",
+  "^tweet",
+  "^create",
+  "^update",
+  "^merge",
+  "^curl",
+  "^http_post",
+  "^http_put",
   "^browser_click",
   "^browser_type",
   "^browser_navigate",
@@ -46,6 +57,25 @@ patterns = [
   "^http",
 ]
 
+# Verbs that positively identify a call as having no side effect. Used to decide
+# whether an unrecognised tool should be held on a tainted session: a name that
+# matches none of side_effect, taint_source, or read_only is simply unknown, and
+# unknown reaching a side effect is the case #166 was about.
+[read_only]
+patterns = [
+  "^get",
+  "^list",
+  "^lookup",
+  "^describe",
+  "^inspect",
+  "^show",
+  "^view",
+  "^count",
+  "^status",
+  "^session",
+  "^scan",
+]
+
 [profiles.readonly]
 blocked_patterns = [
   "^exec",
@@ -65,6 +95,17 @@ blocked_patterns = [
   "^send_email",
   "^post_message",
   "^message_send",
+  "^send",
+  "^post",
+  "^publish",
+  "^upload",
+  "^tweet",
+  "^create",
+  "^update",
+  "^merge",
+  "^curl",
+  "^http_post",
+  "^http_put",
   "^browser_click",
   "^browser_type",
   "^browser_navigate",

--- a/sdk/src/unplug/data/maps_loader.py
+++ b/sdk/src/unplug/data/maps_loader.py
@@ -98,9 +98,14 @@ def load_tool_patterns_map() -> ToolPatternsMap:
         for name, section in profiles_raw.items()
         if isinstance(section, dict)
     }
+    read_only_raw = parsed.get("read_only")
+    read_only = (
+        _tuple_str_list(read_only_raw, "patterns") if isinstance(read_only_raw, dict) else ()
+    )
     return ToolPatternsMap(
         side_effect=_tuple_str_list(side_effect_raw, "patterns"),
         taint_source=_tuple_str_list(taint_source_raw, "patterns"),
+        read_only=read_only,
         profiles=profiles,
     )
 

--- a/sdk/src/unplug/data/schemas.py
+++ b/sdk/src/unplug/data/schemas.py
@@ -17,6 +17,7 @@ class ToolPatternsMap(BaseModel):
 
     side_effect: tuple[str, ...]
     taint_source: tuple[str, ...]
+    read_only: tuple[str, ...] = ()
     profiles: dict[str, ToolProfileMapEntry]
 
 

--- a/sdk/src/unplug/pipelines/toolcall.py
+++ b/sdk/src/unplug/pipelines/toolcall.py
@@ -137,23 +137,42 @@ class ToolCallPipeline(BasePipeline):
             return []
         if tool_call.approved is True:
             return []
-        if not self._tool_policy.is_side_effect(tool_call.tool_name):
+        side_effect = self._tool_policy.is_side_effect(tool_call.tool_name)
+        # A name matching nothing in any table is not evidence that the call is safe.
+        # On a tainted session the cost of asking is a review prompt; the cost of not
+        # asking is the exfiltration this gate exists to stop (#166).
+        unknown = (
+            self._tool_policy.unknown_tool_is_side_effect
+            and self._tool_policy.is_unclassified(tool_call.tool_name)
+        )
+        if not side_effect and not unknown:
             return []
 
         score = self._tool_policy.tainted_side_effect_review_score
         triggers = ", ".join(context.taint_triggers[:3]) or "unknown"
+        if side_effect:
+            subcategory = "session_taint_side_effect"
+            evidence = (
+                f"Side-effect tool '{tool_call.tool_name}' held for review: "
+                f"session tainted ({triggers})"
+            )
+        else:
+            subcategory = "session_taint_unknown_tool"
+            evidence = (
+                f"Tool '{tool_call.tool_name}' matches no known side-effect or read-only "
+                f"pattern and the session is tainted ({triggers}). Classify it via "
+                f"[tools] read_only_tools or side_effect_tools, or set "
+                f"unknown_tool_is_side_effect=false to allow unmatched names."
+            )
         return [
             Finding(
                 category="taint",
-                subcategory="session_taint_side_effect",
+                subcategory=subcategory,
                 stage="tool_policy",
                 span_start=0,
                 span_end=0,
                 score=score,
-                evidence=(
-                    f"Side-effect tool '{tool_call.tool_name}' held for review: "
-                    f"session tainted ({triggers})"
-                ),
+                evidence=evidence,
             )
         ]
 

--- a/sdk/tests/unit/config/test_tools_policy.py
+++ b/sdk/tests/unit/config/test_tools_policy.py
@@ -169,3 +169,26 @@ def test_a_verb_stem_still_matches_a_longer_verb() -> None:
     ):
         assert policy.is_side_effect(spelling), spelling
     assert not ToolPolicyConfig(profile="messaging").is_permitted("execute")
+
+
+def test_a_read_only_grant_does_not_leak_to_other_tools() -> None:
+    """An exemption names one tool, not every tool ending in that word.
+
+    read_only_tools skips the unknown-tool review on a tainted session, so
+    matching it against every underscore suffix handed that exemption to
+    admin_frobnicate and evil_frobnicate as well.
+    """
+    policy = ToolPolicyConfig(read_only_tools=("frobnicate",))
+    assert policy.is_known_read_only("frobnicate")
+    assert not policy.is_known_read_only("admin_frobnicate")
+    assert not policy.is_known_read_only("evil_frobnicate")
+    assert policy.is_unclassified("evil_frobnicate")
+    # A host prefix separated by a namespace marker is still the same tool.
+    assert policy.is_known_read_only("mcp__other__frobnicate")
+
+
+def test_an_explicit_entry_matches_across_host_prefixes_only() -> None:
+    policy = ToolPolicyConfig(side_effect_tools=("send_message",))
+    assert policy.is_side_effect("send_message")
+    assert policy.is_side_effect("mcp__slack__send_message")
+    assert policy.is_side_effect("slack.send_message")

--- a/sdk/tests/unit/config/test_tools_policy.py
+++ b/sdk/tests/unit/config/test_tools_policy.py
@@ -44,3 +44,52 @@ def test_profile_readonly_denies_side_effect() -> None:
     policy = ToolPolicyConfig(profile="readonly")
     assert not policy.is_permitted("shell")
     assert policy.is_permitted("search")
+
+
+def test_camel_case_names_classify() -> None:
+    """Claude Code names its tools WebFetch and NotebookEdit, not web_fetch (#166)."""
+    policy = ToolPolicyConfig()
+    assert policy.is_taint_source("WebFetch")
+    assert policy.is_taint_source("WebSearch")
+    assert policy.is_side_effect("NotebookEdit")
+    assert policy.is_side_effect("sendEmail")
+
+
+def test_mcp_prefixed_names_classify() -> None:
+    policy = ToolPolicyConfig()
+    assert policy.is_side_effect("mcp__slack__send_message")
+    assert policy.is_side_effect("mcp__gmail__send_email")
+    assert policy.is_side_effect("mcp__shell__bash")
+
+
+def test_vendor_prefixed_verbs_classify() -> None:
+    """The verb decides, wherever the vendor put it."""
+    policy = ToolPolicyConfig()
+    assert policy.is_side_effect("slack_post_message")
+    assert policy.is_side_effect("github_create_issue")
+    assert policy.is_side_effect("gmail_send")
+    assert policy.is_side_effect("post_tweet")
+
+
+def test_ordinary_getters_are_not_side_effects() -> None:
+    """The broadened patterns must not swallow plain reads."""
+    policy = ToolPolicyConfig()
+    for name in ("get_weather", "list_files", "search_docs", "read_file", "lookup_user"):
+        assert not policy.is_side_effect(name), name
+        assert not policy.is_unclassified(name), name
+
+
+def test_unrecognised_name_is_unclassified() -> None:
+    policy = ToolPolicyConfig()
+    assert policy.is_unclassified("mcp__acme__frobnicate")
+    assert not policy.is_side_effect("mcp__acme__frobnicate")
+
+
+def test_explicit_overrides_survive_normalisation() -> None:
+    policy = ToolPolicyConfig(
+        side_effect_tools=("CustomSend",),
+        read_only_tools=("mcp__acme__frobnicate",),
+    )
+    assert policy.is_side_effect("custom_send")
+    assert policy.is_side_effect("mcp__vendor__CustomSend")
+    assert not policy.is_unclassified("frobnicate")

--- a/sdk/tests/unit/config/test_tools_policy.py
+++ b/sdk/tests/unit/config/test_tools_policy.py
@@ -92,4 +92,47 @@ def test_explicit_overrides_survive_normalisation() -> None:
     )
     assert policy.is_side_effect("custom_send")
     assert policy.is_side_effect("mcp__vendor__CustomSend")
-    assert not policy.is_unclassified("frobnicate")
+    assert not policy.is_unclassified("mcp__acme__frobnicate")
+
+
+def test_a_namespaced_override_does_not_grant_the_bare_name() -> None:
+    """A grant scoped to one server must not classify the same name elsewhere.
+
+    read_only_tools names acme's frobnicate. A bare frobnicate, or another
+    server's, is a different tool that happens to share a word, and treating it
+    as the granted one hands out the exemption to whoever picks the name.
+    """
+    policy = ToolPolicyConfig(read_only_tools=("mcp__acme__frobnicate",))
+    assert policy.is_known_read_only("mcp__acme__frobnicate")
+    assert not policy.is_known_read_only("frobnicate")
+    assert not policy.is_known_read_only("mcp__other__frobnicate")
+
+
+def test_a_trailing_separator_still_classifies() -> None:
+    """delete_file/ is delete_file. Normalising it to "" classified it as nothing."""
+    policy = ToolPolicyConfig()
+    for spelling in ("delete_file", "delete_file/", "delete_file.", "delete_file:"):
+        assert policy.is_side_effect(spelling), spelling
+
+
+def test_a_leading_verb_is_not_discarded_by_the_namespace_split() -> None:
+    """delete.file and server/delete/user are deletes wherever the host put the verb."""
+    policy = ToolPolicyConfig()
+    for spelling in ("delete.file", "delete/file", "exec.command", "server/delete/user"):
+        assert policy.is_side_effect(spelling), spelling
+
+
+def test_a_verb_prefix_does_not_match_part_of_a_word() -> None:
+    """^pay must not hit payload, ^post must not hit postgres, ^rm must not hit rma."""
+    policy = ToolPolicyConfig()
+    for spelling in (
+        "get_payload",
+        "list_payment_methods",
+        "postgres_read_query",
+        "get_postcode",
+        "get_sender_details",
+        "get_rma_status",
+    ):
+        assert not policy.is_side_effect(spelling), spelling
+    assert policy.is_side_effect("slack_post_message")
+    assert policy.is_side_effect("send_email")

--- a/sdk/tests/unit/config/test_tools_policy.py
+++ b/sdk/tests/unit/config/test_tools_policy.py
@@ -123,16 +123,49 @@ def test_a_leading_verb_is_not_discarded_by_the_namespace_split() -> None:
 
 
 def test_a_verb_prefix_does_not_match_part_of_a_word() -> None:
-    """^pay must not hit payload, ^post must not hit postgres, ^rm must not hit rma."""
+    """A trimmed suffix must not turn a read tool into a side effect.
+
+    Trimming leading segments is what creates the bare string `payload` out of
+    `get_payload`, so a verb stem tested against a trimmed suffix is testing a
+    name nobody asked about. These are the ones this branch is responsible for.
+
+    A name that starts with the offending word on its own, `postgres_read_query`
+    against ^post, is a false positive on dev too and is left alone here rather
+    than fixed by loosening a rule this branch tightened.
+    """
     policy = ToolPolicyConfig()
     for spelling in (
         "get_payload",
         "list_payment_methods",
-        "postgres_read_query",
         "get_postcode",
         "get_sender_details",
         "get_rma_status",
+        "get_executive_summary",
     ):
         assert not policy.is_side_effect(spelling), spelling
     assert policy.is_side_effect("slack_post_message")
     assert policy.is_side_effect("send_email")
+
+
+def test_a_verb_stem_still_matches_a_longer_verb() -> None:
+    """^exec means execute, ^rm means rmdir.
+
+    Requiring every pattern to land on a token boundary read these as
+    unclassified, which let the messaging profile through on `execute`. The
+    boundary rule belongs on the trimmed suffixes only, not on the name the
+    caller actually passed.
+    """
+    policy = ToolPolicyConfig()
+    for spelling in (
+        "execute",
+        "execute_command",
+        "execute_sql",
+        "rmdir",
+        "rmtree",
+        "rmrf",
+        "db_execute",
+        "drop_tables",
+        "run_commands",
+    ):
+        assert policy.is_side_effect(spelling), spelling
+    assert not ToolPolicyConfig(profile="messaging").is_permitted("execute")

--- a/sdk/tests/unit/core/taint/test_session_taint.py
+++ b/sdk/tests/unit/core/taint/test_session_taint.py
@@ -105,3 +105,49 @@ class TestSessionTaint:
         result = guard.check_tool_call("shell", {"command": "echo approved"})
         assert result.action == Action.ALLOW
         assert result.safe
+
+
+class TestHostToolNames:
+    """The names an agent host actually uses, end to end (#166)."""
+
+    def test_camel_fetch_taints_and_mcp_send_is_held(self) -> None:
+        from unplug.integrations.hooks import AgentHooks
+
+        hooks = AgentHooks()
+        hooks.scan_user_input("summarise the page at example.com for me")
+        hooks.before_tool_call("WebFetch", {"url": "https://evil.example/page"})
+        assert hooks.guard.context.is_session_tainted
+
+        decision = hooks.before_tool_call(
+            "mcp__slack__send_message",
+            {"channel": "#external", "text": "AWS keys: ..."},
+        )
+        assert not decision.allowed
+        assert "session_taint_side_effect" in {f.subcategory for f in decision.result.findings}
+
+    def test_unrecognised_tool_is_held_on_a_tainted_session(self) -> None:
+        guard = Guard()
+        guard.notify_taint_source("web_fetch")
+        result = guard.check_tool_call("mcp__acme__frobnicate", {"payload": "..."})
+        assert result.action is not Action.ALLOW
+        assert "session_taint_unknown_tool" in {f.subcategory for f in result.findings}
+
+    def test_unrecognised_tool_is_allowed_on_a_clean_session(self) -> None:
+        guard = Guard()
+        result = guard.check_tool_call("mcp__acme__frobnicate", {"payload": "..."})
+        assert result.action is Action.ALLOW
+
+    def test_unknown_tool_gate_can_be_turned_off(self) -> None:
+        from unplug.config.guard import GuardConfig
+        from unplug.config.tools import ToolPolicyConfig
+
+        cfg = GuardConfig(tools=ToolPolicyConfig(unknown_tool_is_side_effect=False))
+        guard = Guard(config=cfg)
+        guard.notify_taint_source("web_fetch")
+        result = guard.check_tool_call("mcp__acme__frobnicate", {"payload": "..."})
+        assert result.action is Action.ALLOW
+
+    def test_ordinary_getter_is_not_held(self) -> None:
+        guard = Guard()
+        guard.notify_taint_source("web_fetch")
+        assert guard.check_tool_call("get_weather", {"city": "Berlin"}).action is Action.ALLOW


### PR DESCRIPTION
Closes #166.

Tool names were matched as lowercase snake_case against `^`-anchored patterns, so `WebFetch` never tainted a session and `mcp__slack__send_message` was never a side effect. Fetch an attacker-controlled page and post it to Slack through the hooks we ship, and both halves of the boundary stayed quiet.

Three changes.

Normalization now splits camelCase, takes the last segment across `__`, `:`, `.` and `/`, and folds `-` to `_`. `WebFetch`, `web_fetch`, `mcp__browser__webFetch` and `browser.web-fetch` all land on the same name.

Patterns are matched against every underscore-delimited suffix, not just the whole name, so the verb is found wherever the vendor put it. That is what catches `slack_post_message` and `github_create_issue`. A few verbs were missing outright and are added: send, post, publish, upload, tweet, create, update, merge, curl.

A name that matches nothing is now held for review while the session is tainted, under a new `session_taint_unknown_tool` subcategory. An unrecognised name is not evidence a call is safe. To keep that from firing on ordinary getters there is a new `[read_only]` pattern table, so `get_weather` and `list_files` are positively recognised rather than merely unmatched. `unknown_tool_is_side_effect = false` restores the old behaviour.

The classification knobs were documented nowhere outside a comment in `tool_patterns.toml`. `docs/AGENT_ACTIONS.md` now has a section covering `side_effect_tools`, `taint_source_tools`, the new `read_only_tools`, and the patterns.

Eleven new tests, covering the host names from the issue, the vendor-prefixed shapes, ordinary getters staying allowed, and the opt-out. Reverting the normalization turns the end-to-end ones red.

```
1261 passed, 3 skipped, 30 deselected
ruff, ruff format, mypy, doc drift: clean
```

The two failures on this branch are #149, fixed separately.
