### PR TITLE
read flat env vars when the file has a guard table

### DIFF
--- a/sdk/src/unplug/config/loader.py
+++ b/sdk/src/unplug/config/loader.py
@@ -387,10 +387,46 @@ def load(
         file_data = load_from_file(file_path)
     env_data = load_from_env(env_prefix)
     merged = _merge(file_data, env_data)
+    # After the model overrides, not before: UNPLUG_ACTIVE_MODEL creates a [guard]
+    # table where the file had none, which would otherwise strand the flat keys again.
     merged = _apply_model_env_overrides(merged)
+    merged = _promote_flat_env_keys(merged, env_data)
     if not merged:
         return GuardConfig()
     return build_config(merged)
+
+
+def _promote_flat_env_keys(data: dict[str, Any], env_data: dict[str, Any]) -> dict[str, Any]:
+    """Move flat UNPLUG_* settings into [guard] when the file uses a [guard] table.
+
+    ``load_from_env`` writes UNPLUG_REQUIRE_ML at the top level, but ``build_config``
+    reads every guard setting through ``data["guard"]`` as soon as that table exists.
+    So the variables the README tells people to export were silently dropped by anyone
+    who had copied unplug.example.toml, which has a [guard] table (#168). Only two of
+    them, ACTIVE_MODEL and MODEL_PATH, escaped, because they are hand-written into the
+    table by _apply_model_env_overrides.
+
+    Environment wins over the file, matching _merge. The explicit nested form
+    UNPLUG_GUARD__X wins over the flat one, since it says exactly where it belongs.
+    """
+    if "guard" not in data or not isinstance(data["guard"], dict):
+        return data
+    env_guard = env_data.get("guard")
+    already_set = set(env_guard) if isinstance(env_guard, dict) else set()
+
+    promoted = {
+        key: value
+        for key, value in env_data.items()
+        if key in GuardConfig.model_fields
+        and key not in already_set
+        and not isinstance(value, dict)
+    }
+    if not promoted:
+        return data
+
+    out = dict(data)
+    out["guard"] = {**out["guard"], **promoted}
+    return out
 
 
 def _apply_model_env_overrides(data: dict[str, Any]) -> dict[str, Any]:

--- a/sdk/tests/unit/config/test_config_loader.py
+++ b/sdk/tests/unit/config/test_config_loader.py
@@ -283,3 +283,61 @@ blocked_template = "Custom block {category}"
 """)
         cfg = load(file_path=p)
         assert "Custom block" in cfg.messages.blocked_template
+
+
+class TestFlatEnvWithGuardTable:
+    """Flat UNPLUG_* vars must survive a config file that has a [guard] table (#168)."""
+
+    def _write(self, tmp_path: Path) -> Path:
+        cfg = tmp_path / "unplug.toml"
+        cfg.write_text('[guard]\nscanners = ["injection"]\n', encoding="utf-8")
+        return cfg
+
+    def test_require_ml_reaches_the_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("UNPLUG_REQUIRE_ML", "true")
+        assert load(self._write(tmp_path)).require_ml is True
+
+    def test_mode_and_allowlist_reach_the_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("UNPLUG_MODE", "server")
+        monkeypatch.setenv("UNPLUG_SERVER_URL", "https://guard.example")
+        monkeypatch.setenv("UNPLUG_STRICT_SCANNER_ALLOWLIST", "true")
+        cfg = load(self._write(tmp_path))
+        assert cfg.mode == "server"
+        assert cfg.strict_scanner_allowlist is True
+
+    def test_env_beats_the_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg_path = tmp_path / "unplug.toml"
+        cfg_path.write_text("[guard]\nrequire_ml = false\n", encoding="utf-8")
+        monkeypatch.setenv("UNPLUG_REQUIRE_ML", "true")
+        assert load(cfg_path).require_ml is True
+
+    def test_nested_form_beats_the_flat_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("UNPLUG_REQUIRE_ML", "true")
+        monkeypatch.setenv("UNPLUG_GUARD__REQUIRE_ML", "false")
+        assert load(self._write(tmp_path)).require_ml is False
+
+    def test_no_guard_table_still_works(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg_path = tmp_path / "unplug.toml"
+        cfg_path.write_text('scanners = ["injection"]\n', encoding="utf-8")
+        monkeypatch.setenv("UNPLUG_REQUIRE_ML", "true")
+        assert load(cfg_path).require_ml is True
+
+    def test_active_model_does_not_strand_the_flat_keys(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """UNPLUG_ACTIVE_MODEL creates a [guard] table where the file had none."""
+        cfg_path = tmp_path / "unplug.toml"
+        cfg_path.write_text('scanners = ["injection"]\n', encoding="utf-8")
+        monkeypatch.setenv("UNPLUG_ACTIVE_MODEL", "tiny")
+        monkeypatch.setenv("UNPLUG_REQUIRE_ML", "true")
+        cfg = load(cfg_path)
+        assert cfg.active_model == "tiny"
+        assert cfg.require_ml is True


### PR DESCRIPTION
Closes #168.

`load_from_env` writes flat variables at the top level, and `build_config` reads guard settings through `data["guard"]` as soon as that table exists. So `UNPLUG_REQUIRE_ML`, which `sdk/README.md:245` tells people to export, did nothing for anyone who had copied `unplug.example.toml`. Same for `UNPLUG_MODE` and `UNPLUG_STRICT_SCANNER_ALLOWLIST`. Only `ACTIVE_MODEL` and `MODEL_PATH` worked, because they are hand-written into the table by `_apply_model_env_overrides`.

Flat env keys that name a `GuardConfig` field are now merged into the guard table instead of being special-cased one at a time. Environment beats the file, matching `_merge`. The explicit `UNPLUG_GUARD__X` form beats the flat one, since it says exactly where it belongs. Only scalars are promoted, so `scanner_configs` cannot reach a table that would reject it.

One thing worth flagging, because I got it wrong first. This has to run after `_apply_model_env_overrides`, not before: `UNPLUG_ACTIVE_MODEL` creates a `[guard]` table where the file had none, which stranded the flat keys a second way. There is a test for that specific interaction.

Six tests, covering a file with and without a `[guard]` table, env beating the file, the nested form beating the flat one, and the ordering above.

```
1255 passed, 3 skipped, 30 deselected
ruff, ruff format, mypy: clean
```

The two failures on this branch are #149, fixed separately.
