### PR TITLE
ci: add concurrency groups to cancel stale workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [dev, main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/integrations-live.yml
+++ b/.github/workflows/integrations-live.yml
@@ -18,6 +18,10 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pr-scan.yml
+++ b/.github/workflows/pr-scan.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: dev
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -9,6 +9,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/slow-stress.yml
+++ b/.github/workflows/slow-stress.yml
@@ -11,6 +11,10 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/stale-claims.yml
+++ b/.github/workflows/stale-claims.yml
@@ -14,6 +14,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
 

--- a/.github/workflows/stale-claims.yml
+++ b/.github/workflows/stale-claims.yml
@@ -15,7 +15,7 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.dry_run }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/stale-claims.yml
+++ b/.github/workflows/stale-claims.yml
@@ -15,12 +15,11 @@ on:
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.dry_run }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.dry_run == true }}
   cancel-in-progress: true
 
 permissions:
   issues: write
-
 jobs:
   sweep:
     runs-on: ubuntu-latest

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -10,6 +10,10 @@ on:
   issues:
     types: [opened, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
 


### PR DESCRIPTION
# Summary

Adds a `concurrency` group to every workflow in `.github/workflows/` that didn't already have one, so a new push/event cancels the previous in-flight run instead of leaving it running. Closes #108.

Two files were deliberately left unchanged and two required a different group key than the issue's literal snippet — see Notes for reviewers.

## Checklist
- [✅] The issue this closes was assigned to me (see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [✅] This is my only open PR (one issue at a time, see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [✅] Target branch is `dev` (see [BRANCHING.md](BRANCHING.md))
- [✅] `cd sdk && make check-ci` passes locally — N/A for code, but ran YAML validation (`yaml.safe_load` on every edited file) and `git diff --check` (no whitespace errors) since this change touches only `.github/workflows/`, outside `sdk/`
- [✅] New code has tests — N/A, workflow config only, no application code changed
- [✅] Public API changes are reflected in `sdk/README.md` / `docs/` — N/A, no public API changed
- [✅] No secrets, internal URLs, or private paths in the diff
- [✅] If a model wrote a meaningful part of this, I said so below ([AI_POLICY.md](../AI_POLICY.md))

## Notes for reviewers

Standard block added to: `ci.yml`, `integrations-live.yml`, `label.yml`, `pr-scan.yml`, `slow-stress.yml`, `stale-claims.yml`.

Deviations from the issue's exact snippet:

- docs.yml— already had a concurrency block (`group: docs-${{ github.ref }}`, `cancel-in-progress: true`); left unchanged.
- reusable-agent-scan.yml — skipped. It only runs via workflow_call, so it has no independent trigger/concurrency lifecycle of its own — the calling workflow (`pr-scan.yml`) already carries its own group.
- publish-pypi.yml — added the block with `cancel-in-progress: false`, per the issue's explicit caveat, so an in-flight release publish is never cancelled.
- triage.yml — added the block, but keyed the group on `github.event.issue.number` instead of `github.ref`. This workflow triggers on `issues: opened/reopened`, where `github.ref` isn't meaningfully scoped to a specific issue — using it as written would put every new issue in the repo into one shared concurrency group, so opening an unrelated issue could cancel the in-flight triage run for a different issue. Scoping to the issue number keeps cancellation limited to re-runs on the same issue.
- edit : Fixed both — label.yml now groups by PR number (github.ref resolves to the base branch on pull_request_target, so grouping by ref was letting unrelated PRs cancel each other's labeling runs). stale-claims.yml now includes dry_run in the group key, so a manual dry run can't collide with the real mutating sweep.
edit 2 : Fixed — inputs.dry_run is undefined (empty string) on schedule triggers but the literal string "false" on a manual non-dry workflow_dispatch, so the two real-sweep paths were landing in different groups and could race. Comparing with `inputs.dry_run == true` normalizes both to the same boolean-false group, while a genuine dry run still gets isolated into its own group.
Drafted with AI assistance for the  `workflow_call`/`issues`-trigger deviations above; I reviewed each workflow's actual trigger semantics myself before deciding where the standard snippet did or didn't apply as-is.
