### PR TITLE
ci(deps): watch root docs-requirements.txt with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,11 @@ updates:
     target-branch: dev
     labels:
       - dependencies
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    target-branch: dev
+    labels:
+      - dependencies


### PR DESCRIPTION
    Added a third dependabot block (pip, directory: /) so the pinned
    packages in docs-requirements.txt (mkdocs, mkdocs-material) get
    weekly dependency updates. The existing pip watcher only covers /sdk,
    leaving the docs pins unpatched, this block covers the root and opens
    its own PRs since grouping across directories isn't possible.

    Closes #165

# Summary

<!-- What does this PR change, and why? -->

## Checklist

- [X] The issue this closes was assigned to me (see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [X] This is my only open PR (one issue at a time, see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [X] Target branch is `dev` (see [BRANCHING.md](BRANCHING.md))
- [ ] `cd sdk && make check-ci` passes locally
- [ ] New code has tests (every module gets a test file)
- [ ] Public API changes are reflected in `sdk/README.md` / `docs/`
- [X] No secrets, internal URLs, or private paths in the diff
- [ ] If a model wrote a meaningful part of this, I said so below ([AI_POLICY.md](../AI_POLICY.md))
