### PR TITLE
ci: pinned composite action to SHAs and fixed stale checkout comment

### DIFF
--- a/.github/actions/unplug-scan/action.yml
+++ b/.github/actions/unplug-scan/action.yml
@@ -27,13 +27,13 @@ runs:
   using: composite
   steps:
     - name: Set up uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         enable-cache: true
         version: "0.6.14"
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/integrations-live.yml
+++ b/.github/workflows/integrations-live.yml
@@ -69,7 +69,7 @@ jobs:
       run:
         working-directory: sdk
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:


### PR DESCRIPTION
    Pinned astral-sh/setup-uv and actions/setup-python in the unplug-scan
    composite action to the SHAs the workflows already use instead of
    mutable major tags. And also corrected the actions/checkout comment in
    integrations-live.yml, which said v6 for a v7.0.1 SHA.

    Closes #172

# Summary

 - Pinned `astral-sh/setup-uv` and `actions/setup-python` in `.github/actions/unplug-scan/action.yml` to the same SHAs already    used in  `ci.yml`, replacing the mutable major tags.
 - Fixed the `actions/checkout` comment in `integrations-live.yml:72` as the SHA is v7.0.1, not v6.

## Checklist

- [X] The issue this closes was assigned to me (see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [X] This is my only open PR (one issue at a time, see [CONTRIBUTING.md](../CONTRIBUTING.md#claiming-an-issue))
- [X] Target branch is `dev` (see [BRANCHING.md](BRANCHING.md))
- [ ] `cd sdk && make check-ci` passes locally
- [ ] New code has tests (every module gets a test file)
- [ ] Public API changes are reflected in `sdk/README.md` / `docs/`
- [X] No secrets, internal URLs, or private paths in the diff
- [ ] If a model wrote a meaningful part of this, I said so below ([AI_POLICY.md](../AI_POLICY.md))


